### PR TITLE
3 job assertions

### DIFF
--- a/src/main/java/io/camunda/testing/assertions/BpmnAssertions.java
+++ b/src/main/java/io/camunda/testing/assertions/BpmnAssertions.java
@@ -1,5 +1,6 @@
 package io.camunda.testing.assertions;
 
+import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import org.camunda.community.eze.RecordStreamSource;
 
@@ -7,12 +8,16 @@ public abstract class BpmnAssertions {
 
   static ThreadLocal<RecordStreamSource> recordStreamSource = new ThreadLocal<>();
 
-  public static void init(RecordStreamSource recordStreamSource) {
+  public static void init(final RecordStreamSource recordStreamSource) {
     BpmnAssertions.recordStreamSource.set(recordStreamSource);
   }
 
   public static ProcessInstanceAssertions assertThat(final ProcessInstanceEvent instanceEvent) {
     return new ProcessInstanceAssertions(instanceEvent, getRecordStreamSource());
+  }
+
+  public static JobAssert assertThat(final ActivatedJob activatedJob) {
+    return new JobAssert(activatedJob);
   }
 
   private static RecordStreamSource getRecordStreamSource() {

--- a/src/main/java/io/camunda/testing/assertions/JobAssert.java
+++ b/src/main/java/io/camunda/testing/assertions/JobAssert.java
@@ -1,0 +1,105 @@
+package io.camunda.testing.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.data.Offset;
+
+// TODO discuss name: job assertions, service task assertions, worker assertions
+
+/** Assertions for {@code ActivatedJob} instances */
+public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {
+
+  public JobAssert(final ActivatedJob actual) {
+    super(actual, JobAssert.class);
+  }
+
+  /**
+   * Asserts that the activated job is associated to an element with the given id
+   *
+   * @param expectedElementId element id to check
+   * @return this {@link JobAssert}
+   */
+  public JobAssert hasElementId(final String expectedElementId) {
+    assertThat(expectedElementId).describedAs("expectedElementId").isNotNull().isNotEmpty();
+    final String actualElementId = actual.getElementId();
+
+    assertThat(actualElementId)
+        .overridingErrorMessage(
+            "Job is not associated with expected element id '%s' but is instead associated with '%s'",
+            expectedElementId, actualElementId)
+        .isEqualTo(expectedElementId);
+    return this;
+  }
+
+  // TODO decide whether this assertion has any value
+
+  /**
+   * Asserts that the activated job has the given deadline
+   *
+   * @param expectedDeadline deadline in terms of {@code System.currentTimeMillis()}
+   * @param offset offset in milliseconds to tolerate timing invariances
+   * @return this {@link JobAssert}
+   */
+  public JobAssert hasDeadline(final long expectedDeadline, final Offset<Long> offset) {
+    assertThat(offset).describedAs("Offset").isNotNull();
+    final long actualDeadline = actual.getDeadline();
+
+    assertThat(actualDeadline).describedAs("Deadline").isCloseTo(expectedDeadline, offset);
+    return this;
+  }
+
+  /**
+   * Asserts that the activated job is associated to the given process id
+   *
+   * @param expectedBpmnProcessId proces id to check
+   * @return this {@link JobAssert}
+   */
+  public JobAssert hasBpmnProcessId(final String expectedBpmnProcessId) {
+    assertThat(expectedBpmnProcessId).describedAs("expectedBpmnProcessId").isNotNull().isNotEmpty();
+    final String actualBpmnProcessId = actual.getBpmnProcessId();
+
+    assertThat(actualBpmnProcessId)
+        .overridingErrorMessage(
+            "Job is not associated with BPMN process id '%s' but is instead associated with '%s'",
+            expectedBpmnProcessId, actualBpmnProcessId)
+        .isEqualTo(expectedBpmnProcessId);
+    return this;
+  }
+
+  /**
+   * Asserts that the activated job has the given number of retries
+   *
+   * @param expectedRetries expected retries
+   * @return this {@link JobAssert}
+   */
+  public JobAssert hasRetries(final int expectedRetries) {
+    final int actualRetries = actual.getRetries();
+
+    assertThat(actualRetries)
+        .overridingErrorMessage(
+            "Job does not have %d retries but instead %d", expectedRetries, actualRetries)
+        .isEqualTo(expectedRetries);
+    return this;
+  }
+
+  /**
+   * Extracts the variables of the activated job.
+   *
+   * @return this {@link JobAssert}
+   */
+  public MapAssert<String, Object> extractingVariables() {
+    return assertThat(actual.getVariablesAsMap()).describedAs("Variables");
+  }
+
+  /**
+   * Extracts the header values of the activated job.
+   *
+   * @return this {@link JobAssert}
+   */
+  public MapAssert<String, String> extractingHeaders() {
+    return assertThat(actual.getCustomHeaders()).describedAs("Headers");
+  }
+}

--- a/src/main/java/io/camunda/testing/assertions/JobAssert.java
+++ b/src/main/java/io/camunda/testing/assertions/JobAssert.java
@@ -7,8 +7,6 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.data.Offset;
 
-// TODO discuss name: job assertions, service task assertions, worker assertions
-
 /** Assertions for {@code ActivatedJob} instances */
 public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {
 
@@ -27,8 +25,8 @@ public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {
     final String actualElementId = actual.getElementId();
 
     assertThat(actualElementId)
-        .overridingErrorMessage(
-            "Job is not associated with expected element id '%s' but is instead associated with '%s'",
+        .withFailMessage(
+            "Job is not associated with expected element id '%s' but is instead associated with '%s'.",
             expectedElementId, actualElementId)
         .isEqualTo(expectedElementId);
     return this;
@@ -62,8 +60,8 @@ public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {
     final String actualBpmnProcessId = actual.getBpmnProcessId();
 
     assertThat(actualBpmnProcessId)
-        .overridingErrorMessage(
-            "Job is not associated with BPMN process id '%s' but is instead associated with '%s'",
+        .withFailMessage(
+            "Job is not associated with BPMN process id '%s' but is instead associated with '%s'.",
             expectedBpmnProcessId, actualBpmnProcessId)
         .isEqualTo(expectedBpmnProcessId);
     return this;
@@ -79,8 +77,9 @@ public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {
     final int actualRetries = actual.getRetries();
 
     assertThat(actualRetries)
-        .overridingErrorMessage(
-            "Job does not have %d retries but instead %d", expectedRetries, actualRetries)
+        .withFailMessage(
+            "Job does not have %d retries, as expected, but instead has %d retries.",
+            expectedRetries, actualRetries)
         .isEqualTo(expectedRetries);
     return this;
   }

--- a/src/test/java/io/camunda/testing/assertions/JobAssertTest.java
+++ b/src/test/java/io/camunda/testing/assertions/JobAssertTest.java
@@ -1,0 +1,285 @@
+package io.camunda.testing.assertions;
+
+import static io.camunda.testing.assertions.BpmnAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.data.Offset.offset;
+
+import io.camunda.testing.extensions.ZeebeAssertions;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.camunda.community.eze.RecordStreamSource;
+import org.camunda.community.eze.ZeebeEngine;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+// TODO remove Thread.sleeps
+@ZeebeAssertions
+class JobAssertTest {
+
+  public static final String PROCESS_INSTANCE_BPMN = "looping-servicetask.bpmn";
+  public static final String PROCESS_INSTANCE_ID = "looping-servicetask";
+  public static final String ELEMENT_ID = "servicetask";
+  public static final String WRONG_VALUE = "wrong value";
+
+  private ZeebeClient client;
+  private ZeebeEngine engine;
+
+  // These tests are for testing assertions as well as examples for users
+  @Nested
+  class HappyPathTests {
+
+    private RecordStreamSource recordStreamSource;
+
+    @Test
+    void testHasElementId() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final ActivateJobsResponse jobActivationResponse =
+          client.newActivateJobsCommand().jobType("test").maxJobsToActivate(1).send().join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+      assertThat(actual).hasElementId(ELEMENT_ID);
+    }
+
+    @Test
+    void testHasDeadline() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final long expectedDeadline = System.currentTimeMillis() + 100;
+      final ActivateJobsResponse jobActivationResponse =
+          client
+              .newActivateJobsCommand()
+              .jobType("test")
+              .maxJobsToActivate(1)
+              .timeout(Duration.ofMillis(100))
+              .send()
+              .join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+      assertThat(actual).hasDeadline(expectedDeadline, offset(20L));
+    }
+
+    @Test
+    void testHasBpmnProcessId() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final ActivateJobsResponse jobActivationResponse =
+          client.newActivateJobsCommand().jobType("test").maxJobsToActivate(1).send().join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+      assertThat(actual).hasBpmnProcessId(PROCESS_INSTANCE_ID);
+    }
+
+    @Test
+    void testHasRetries() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final ActivateJobsResponse jobActivationResponse =
+          client.newActivateJobsCommand().jobType("test").maxJobsToActivate(1).send().join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+      assertThat(actual).hasRetries(1);
+    }
+
+    @Test
+    void testExtractingVariables() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final ActivateJobsResponse jobActivationResponse =
+          client.newActivateJobsCommand().jobType("test").maxJobsToActivate(1).send().join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+      assertThat(actual)
+          .extractingVariables()
+          .containsOnly(entry("totalLoops", 1), entry("loopAmount", 0));
+    }
+
+    @Test
+    void testExtractingHeaders() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final ActivateJobsResponse jobActivationResponse =
+          client.newActivateJobsCommand().jobType("test").maxJobsToActivate(1).send().join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+      assertThat(actual).extractingHeaders().isEmpty();
+    }
+  }
+
+  // These tests are just for assertion testing purposes. These should not be used as examples.
+  @Nested
+  class UnhappyPathTests {
+    private RecordStreamSource recordStreamSource;
+
+    @Test
+    void testHasElementIdFailure() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final ActivateJobsResponse jobActivationResponse =
+          client.newActivateJobsCommand().jobType("test").maxJobsToActivate(1).send().join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+
+      assertThatThrownBy(() -> assertThat(actual).hasElementId(WRONG_VALUE))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContainingAll(ELEMENT_ID, WRONG_VALUE);
+    }
+
+    @Test
+    void testHasDeadlineFailure() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final long expectedDeadline = System.currentTimeMillis() + 100;
+      final ActivateJobsResponse jobActivationResponse =
+          client
+              .newActivateJobsCommand()
+              .jobType("test")
+              .maxJobsToActivate(1)
+              .timeout(Duration.ofMillis(100))
+              .send()
+              .join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+      assertThatThrownBy(() -> assertThat(actual).hasDeadline(-1, offset(20L)))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContainingAll("Deadline", "-1", "20");
+    }
+
+    @Test
+    void testHasBpmnProcessIdFailure() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final ActivateJobsResponse jobActivationResponse =
+          client.newActivateJobsCommand().jobType("test").maxJobsToActivate(1).send().join();
+
+      // then
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+
+      assertThatThrownBy(() -> assertThat(actual).hasBpmnProcessId(WRONG_VALUE))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContainingAll(PROCESS_INSTANCE_ID, WRONG_VALUE);
+    }
+
+    @Test
+    void testHasRetriesFailure() throws InterruptedException {
+      // given
+      deployProcess(PROCESS_INSTANCE_BPMN);
+      final Map<String, Object> variables = Collections.singletonMap("totalLoops", 1);
+      startProcessInstance(PROCESS_INSTANCE_ID, variables);
+
+      // when
+      final ActivateJobsResponse jobActivationResponse =
+          client.newActivateJobsCommand().jobType("test").maxJobsToActivate(1).send().join();
+
+      // then
+
+      final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
+      assertThatThrownBy(() -> assertThat(actual).hasRetries(12345))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContainingAll("1", "12345");
+    }
+  }
+
+  private void deployProcess(final String process) {
+    client.newDeployCommand().addResourceFromClasspath(process).send().join();
+  }
+
+  private ProcessInstanceEvent startProcessInstance(final String processId)
+      throws InterruptedException {
+    return startProcessInstance(processId, new HashMap<>());
+  }
+
+  private ProcessInstanceEvent startProcessInstance(
+      final String processId, final Map<String, Object> variables) throws InterruptedException {
+    final ProcessInstanceEvent instanceEvent =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variables(variables)
+            .send()
+            .join();
+    Thread.sleep(100);
+    return instanceEvent;
+  }
+
+  // TODO we need a proper way to complete jobs instead of this hack
+  private void completeTask(final String elementId) throws InterruptedException {
+    Thread.sleep(100);
+    Record<JobRecordValue> lastRecord = null;
+    for (final Record<JobRecordValue> record : engine.jobRecords().withElementId(elementId)) {
+      if (record.getIntent().equals(JobIntent.CREATED)) {
+        lastRecord = record;
+      }
+    }
+    if (lastRecord != null) {
+      client.newCompleteCommand(lastRecord.getKey()).send().join();
+    }
+    Thread.sleep(100);
+  }
+
+  private void sendMessage(final String messsageName, final String correlationKey)
+      throws InterruptedException {
+    client
+        .newPublishMessageCommand()
+        .messageName(messsageName)
+        .correlationKey(correlationKey)
+        .send()
+        .join();
+    Thread.sleep(100);
+  }
+}


### PR DESCRIPTION
## Description

Adds assertions for jobs.

## Related issues
closes #3

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] The documentation is updated
