### PR TITLE
Add variable assertions

### DIFF
--- a/src/main/java/io/camunda/testing/assertions/ProcessInstanceAssertions.java
+++ b/src/main/java/io/camunda/testing/assertions/ProcessInstanceAssertions.java
@@ -392,6 +392,12 @@ public class ProcessInstanceAssertions
     return openMessageSubscriptions;
   }
 
+  /**
+   * Verifies the process instance has a variable with the specified name
+   *
+   * @param name The name of the variable
+   * @return this ${@link ProcessInstanceAssertions}
+   */
   public ProcessInstanceAssertions hasVariable(final String name) {
     final Map<String, String> variables = getProcessInstanceVariables();
     return assertVariableInMapOfVariables(name, variables);
@@ -418,6 +424,13 @@ public class ProcessInstanceAssertions
     return this;
   }
 
+  /**
+   * Verifies the process instance has a variable with a specific value.
+   *
+   * @param name The name of the variable
+   * @param value The value of the variable
+   * @return this ${@link ProcessInstanceAssertions}
+   */
   public ProcessInstanceAssertions hasVariableWithValue(final String name, final String value) {
     final ZeebeObjectMapper mapper = new ZeebeObjectMapper();
     final String mappedValue = mapper.toJson(value);
@@ -426,13 +439,20 @@ public class ProcessInstanceAssertions
     assertVariableInMapOfVariables(name, variables);
     assertThat(variables)
         .withFailMessage(
-            "Variable '%s' does not have value '%s', as expected, but instead has the value '%s'",
-            name, value, variables.get(name))
+            "The variable '%s' does not have the expected value. The value passed in"
+                + " ('%s') is internally mapped to a JSON String that yields '%s'. However, the "
+                + "actual value (as JSON String) is '%s.",
+            name, value, mappedValue, variables.get(name))
         .containsEntry(name, mappedValue);
 
     return this;
   }
 
+  /**
+   * Returns a Map of variables that belong to this process instance
+   *
+   * @return map of variables
+   */
   private Map<String, String> getProcessInstanceVariables() {
     return StreamFilter.variable(recordStreamSource)
         .withProcessInstanceKey(actual.getProcessInstanceKey())

--- a/src/main/java/io/camunda/testing/assertions/ProcessInstanceAssertions.java
+++ b/src/main/java/io/camunda/testing/assertions/ProcessInstanceAssertions.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.testing.filters.StreamFilter;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -19,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.SoftAssertions;
 import org.camunda.community.eze.RecordStreamSource;
 
@@ -393,32 +393,52 @@ public class ProcessInstanceAssertions
   }
 
   public ProcessInstanceAssertions hasVariable(final String name) {
-    extractVariables()
+    final Map<String, String> variables = getProcessInstanceVariables();
+    return assertVariableInMapOfVariables(name, variables);
+  }
+
+  /**
+   * Assert that the given variable name is a key in the given map of variables.
+   *
+   * <p>This assertion has been extracted from the method ${@link #hasVariable(String)} so that the
+   * method ${@link #hasVariableWithValue(String, String)} could reuse it without having to traverse
+   * the record stream to collect the variables a second time.
+   *
+   * @param name The name of the variable
+   * @param variables The map of variables
+   * @return this ${@link ProcessInstanceAssertions}
+   */
+  private ProcessInstanceAssertions assertVariableInMapOfVariables(
+      final String name, final Map<String, String> variables) {
+    assertThat(variables)
         .withFailMessage(
-            "Process with key %s does not contain variable with name %s",
-            actual.getProcessInstanceKey(), name)
+            "Process with key %s does not contain variable with name `%s`. Available variables are: %s",
+            actual.getProcessInstanceKey(), name, variables.keySet())
         .containsKey(name);
     return this;
   }
 
   public ProcessInstanceAssertions hasVariableWithValue(final String name, final String value) {
-    extractVariables()
+    final ZeebeObjectMapper mapper = new ZeebeObjectMapper();
+    final String mappedValue = mapper.toJson(value);
+    final Map<String, String> variables = getProcessInstanceVariables();
+
+    assertVariableInMapOfVariables(name, variables);
+    assertThat(variables)
         .withFailMessage(
-            "Process with key %s does not contain variable with name %s and value %s",
-            actual.getProcessInstanceKey(), name, value)
-        .containsEntry(name, value);
+            "Variable '%s' does not have value '%s', as expected, but instead has the value '%s'",
+            name, value, variables.get(name))
+        .containsEntry(name, mappedValue);
+
     return this;
   }
 
-  public MapAssert<String, String> extractVariables() {
-    final Map<String, String> variables =
-        StreamFilter.variable(recordStreamSource)
-            .withProcessInstanceKey(actual.getProcessInstanceKey())
-            .withRejectionType(RejectionType.NULL_VAL)
-            .stream()
-            .map(Record::getValue)
-            .collect(Collectors.toMap(VariableRecordValue::getName, VariableRecordValue::getValue));
-
-    return new MapAssert<>(variables);
+  private Map<String, String> getProcessInstanceVariables() {
+    return StreamFilter.variable(recordStreamSource)
+        .withProcessInstanceKey(actual.getProcessInstanceKey())
+        .withRejectionType(RejectionType.NULL_VAL)
+        .stream()
+        .map(Record::getValue)
+        .collect(Collectors.toMap(VariableRecordValue::getName, VariableRecordValue::getValue));
   }
 }

--- a/src/main/java/io/camunda/testing/filters/StreamFilter.java
+++ b/src/main/java/io/camunda/testing/filters/StreamFilter.java
@@ -14,4 +14,8 @@ public class StreamFilter {
     return new ProcessMessageSubscriptionRecordStreamFilter(
         recordStreamSource.processMessageSubscriptionRecords());
   }
+
+  public static VariableRecordStreamFilter variable(final RecordStreamSource recordStreamSource) {
+    return new VariableRecordStreamFilter(recordStreamSource.variableRecords());
+  }
 }

--- a/src/main/java/io/camunda/testing/filters/VariableRecordStreamFilter.java
+++ b/src/main/java/io/camunda/testing/filters/VariableRecordStreamFilter.java
@@ -24,7 +24,8 @@ public class VariableRecordStreamFilter {
   }
 
   public VariableRecordStreamFilter withRejectionType(final RejectionType rejectionType) {
-    return new VariableRecordStreamFilter(stream.filter(record -> record.getRejectionType() == rejectionType));
+    return new VariableRecordStreamFilter(
+        stream.filter(record -> record.getRejectionType() == rejectionType));
   }
 
   public Stream<Record<VariableRecordValue>> stream() {

--- a/src/main/java/io/camunda/testing/filters/VariableRecordStreamFilter.java
+++ b/src/main/java/io/camunda/testing/filters/VariableRecordStreamFilter.java
@@ -1,0 +1,33 @@
+package io.camunda.testing.filters;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class VariableRecordStreamFilter {
+
+  private Stream<Record<VariableRecordValue>> stream;
+
+  public VariableRecordStreamFilter(final Iterable<Record<VariableRecordValue>> records) {
+    stream = StreamSupport.stream(records.spliterator(), false);
+  }
+
+  public VariableRecordStreamFilter(final Stream<Record<VariableRecordValue>> stream) {
+    this.stream = stream;
+  }
+
+  public VariableRecordStreamFilter withProcessInstanceKey(final long processInstanceKey) {
+    return new VariableRecordStreamFilter(
+        stream.filter(record -> record.getValue().getProcessInstanceKey() == processInstanceKey));
+  }
+
+  public VariableRecordStreamFilter withRejectionType(final RejectionType rejectionType) {
+    return new VariableRecordStreamFilter(stream.filter(record -> record.getRejectionType() == rejectionType));
+  }
+
+  public Stream<Record<VariableRecordValue>> stream() {
+    return stream;
+  }
+}

--- a/src/test/java/io/camunda/testing/assertions/ProcessInstanceAssertionsTest.java
+++ b/src/test/java/io/camunda/testing/assertions/ProcessInstanceAssertionsTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import org.camunda.community.eze.RecordStreamSource;
 import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
@@ -326,7 +325,7 @@ class ProcessInstanceAssertionsTest {
     public void testProcessInstanceHasVariableWithValue() throws InterruptedException {
       // given
       deployProcess(PROCESS_INSTANCE_BPMN);
-      final Map<String, Object> variables = Collections.singletonMap(VAR_TOTAL_LOOPS, 1);
+      final Map<String, Object> variables = Collections.singletonMap(VAR_TOTAL_LOOPS, "1");
 
       // when
       final ProcessInstanceEvent instanceEvent =
@@ -713,17 +712,18 @@ class ProcessInstanceAssertionsTest {
     public void testProcessInstanceHasVariableFailure() throws InterruptedException {
       // given
       deployProcess(PROCESS_INSTANCE_BPMN);
-      final String variable = "variable";
+      final String expectedVariable = "variable";
+      final String actualVariable = "loopAmount";
 
       // when
       final ProcessInstanceEvent instanceEvent = startProcessInstance(PROCESS_INSTANCE_ID);
 
       // then
-      assertThatThrownBy(() -> assertThat(instanceEvent).hasVariable(variable))
+      assertThatThrownBy(() -> assertThat(instanceEvent).hasVariable(expectedVariable))
           .isInstanceOf(AssertionError.class)
           .hasMessage(
-              "Process with key %s does not contain variable with name %s",
-              instanceEvent.getProcessInstanceKey(), variable);
+              "Process with key %s does not contain variable with name `%s`. Available variables are: [%s]",
+              instanceEvent.getProcessInstanceKey(), expectedVariable, actualVariable);
     }
 
     @Test
@@ -731,8 +731,9 @@ class ProcessInstanceAssertionsTest {
       // given
       deployProcess(PROCESS_INSTANCE_BPMN);
       final String variable = "variable";
-      final String variableValue = "wrongvalue";
-      final Map<String, Object> variables = Collections.singletonMap(variable, "value");
+      final String expectedValue = "expectedValue";
+      final String actualValue = "actualValue";
+      final Map<String, Object> variables = Collections.singletonMap(variable, actualValue);
 
       // when
       final ProcessInstanceEvent instanceEvent =
@@ -740,11 +741,11 @@ class ProcessInstanceAssertionsTest {
 
       // then
       assertThatThrownBy(
-              () -> assertThat(instanceEvent).hasVariableWithValue(variable, variableValue))
+              () -> assertThat(instanceEvent).hasVariableWithValue(variable, expectedValue))
           .isInstanceOf(AssertionError.class)
           .hasMessage(
-              "Process with key %s does not contain variable with name %s and value %s",
-              instanceEvent.getProcessInstanceKey(), variable, variableValue);
+              "Variable '%s' does not have value '%s', as expected, but instead has the value '\"%s\"'",
+              variable, expectedValue, actualValue);
     }
   }
 

--- a/src/test/java/io/camunda/testing/assertions/ProcessInstanceAssertionsTest.java
+++ b/src/test/java/io/camunda/testing/assertions/ProcessInstanceAssertionsTest.java
@@ -744,8 +744,10 @@ class ProcessInstanceAssertionsTest {
               () -> assertThat(instanceEvent).hasVariableWithValue(variable, expectedValue))
           .isInstanceOf(AssertionError.class)
           .hasMessage(
-              "Variable '%s' does not have value '%s', as expected, but instead has the value '\"%s\"'",
-              variable, expectedValue, actualValue);
+              "The variable '%s' does not have the expected value. The value passed in"
+                  + " ('%s') is internally mapped to a JSON String that yields '\"%s\"'. However, the "
+                  + "actual value (as JSON String) is '\"%s\".",
+              variable, expectedValue, expectedValue, actualValue);
     }
   }
 


### PR DESCRIPTION
## Description

This change makes it possible to assert against the variables of a process. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] The documentation is updated
