### PR TITLE
Timer assertions

### DIFF
--- a/src/main/java/io/camunda/testing/assertions/BpmnAssert.java
+++ b/src/main/java/io/camunda/testing/assertions/BpmnAssert.java
@@ -1,7 +1,8 @@
 package io.camunda.testing.assertions;
 
-import static io.camunda.testing.utils.RecordStreamManager.getRecordStreamSource;
+import static io.camunda.testing.utils.RecordStreamSourceStore.getRecordStreamSource;
 
+import io.camunda.testing.utils.model.InspectedProcessInstance;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
@@ -12,6 +13,12 @@ public abstract class BpmnAssert {
   public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent instanceEvent) {
     return new ProcessInstanceAssert(
         instanceEvent.getProcessInstanceKey(), getRecordStreamSource());
+  }
+
+  public static ProcessInstanceAssert assertThat(
+      final InspectedProcessInstance inspectedProcessInstance) {
+    return new ProcessInstanceAssert(
+        inspectedProcessInstance.getProcessInstanceKey(), getRecordStreamSource());
   }
 
   public static JobAssert assertThat(final ActivatedJob activatedJob) {

--- a/src/main/java/io/camunda/testing/assertions/BpmnAssert.java
+++ b/src/main/java/io/camunda/testing/assertions/BpmnAssert.java
@@ -1,22 +1,13 @@
 package io.camunda.testing.assertions;
 
+import static io.camunda.testing.utils.RecordStreamManager.getRecordStreamSource;
+
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
-import org.camunda.community.eze.RecordStreamSource;
 
 public abstract class BpmnAssert {
-
-  static ThreadLocal<RecordStreamSource> recordStreamSource = new ThreadLocal<>();
-
-  public static void init(final RecordStreamSource recordStreamSource) {
-    BpmnAssert.recordStreamSource.set(recordStreamSource);
-  }
-
-  public static void reset() {
-    recordStreamSource.remove();
-  }
 
   public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent instanceEvent) {
     return new ProcessInstanceAssert(
@@ -33,14 +24,5 @@ public abstract class BpmnAssert {
 
   public static MessageAssert assertThat(final PublishMessageResponse publishMessageResponse) {
     return new MessageAssert(publishMessageResponse, getRecordStreamSource());
-  }
-
-  private static RecordStreamSource getRecordStreamSource() {
-    if (recordStreamSource.get() == null) {
-      throw new AssertionError(
-          "No RecordStreamSource is set. Please use @ZeebeAssertions extension and "
-              + "declare a RecordStreamSource field");
-    }
-    return recordStreamSource.get();
   }
 }

--- a/src/main/java/io/camunda/testing/extensions/ZeebeAssertionsExtension.java
+++ b/src/main/java/io/camunda/testing/extensions/ZeebeAssertionsExtension.java
@@ -1,6 +1,6 @@
 package io.camunda.testing.extensions;
 
-import io.camunda.testing.assertions.BpmnAssert;
+import io.camunda.testing.utils.RecordStreamSourceStore;
 import io.camunda.zeebe.client.ZeebeClient;
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -27,7 +27,7 @@ public class ZeebeAssertionsExtension implements BeforeEachCallback, AfterEachCa
     final Object testInstance = extensionContext.getTestInstance().get();
     final RecordStreamSource recordStreamSource =
         (RecordStreamSource) recordStreamField.get(testInstance);
-    BpmnAssert.init(recordStreamSource);
+    RecordStreamSourceStore.init(recordStreamSource);
 
     final Optional<Field> zeebeClientOptional =
         Arrays.stream(extensionContext.getTestClass().get().getDeclaredFields())
@@ -42,7 +42,7 @@ public class ZeebeAssertionsExtension implements BeforeEachCallback, AfterEachCa
 
   @Override
   public void afterEach(final ExtensionContext extensionContext) {
-    BpmnAssert.reset();
+    RecordStreamSourceStore.reset();
 
     final Object fieldContent = getStore(extensionContext).get(KEY_ZEEBE_CLIENT);
     final ZeebeClient zeebeClient = (ZeebeClient) fieldContent;

--- a/src/main/java/io/camunda/testing/filters/ProcessEventRecordStreamFilter.java
+++ b/src/main/java/io/camunda/testing/filters/ProcessEventRecordStreamFilter.java
@@ -1,0 +1,44 @@
+package io.camunda.testing.filters;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class ProcessEventRecordStreamFilter {
+
+  private final Stream<Record<ProcessEventRecordValue>> stream;
+
+  public ProcessEventRecordStreamFilter(final Iterable<Record<?>> records) {
+    stream =
+        StreamSupport.stream(records.spliterator(), true)
+            .filter(record -> record.getValueType() == ValueType.PROCESS_EVENT)
+            .map(record -> (Record<ProcessEventRecordValue>) record);
+  }
+
+  public ProcessEventRecordStreamFilter(final Stream<Record<ProcessEventRecordValue>> stream) {
+    this.stream = stream;
+  }
+
+  public ProcessEventRecordStreamFilter withIntent(final ProcessEventIntent intent) {
+    return new ProcessEventRecordStreamFilter(
+        stream.filter(record -> record.getIntent() == intent));
+  }
+
+  public ProcessEventRecordStreamFilter withTargetElementId(final String targetElementId) {
+    return new ProcessEventRecordStreamFilter(
+        stream.filter(record -> record.getValue().getTargetElementId().equals(targetElementId)));
+  }
+
+  public ProcessEventRecordStreamFilter withProcessDefinitionKey(final long processDefinitionKey) {
+    return new ProcessEventRecordStreamFilter(
+        stream.filter(
+            record -> record.getValue().getProcessDefinitionKey() == processDefinitionKey));
+  }
+
+  public Stream<Record<ProcessEventRecordValue>> stream() {
+    return stream;
+  }
+}

--- a/src/main/java/io/camunda/testing/filters/StreamFilter.java
+++ b/src/main/java/io/camunda/testing/filters/StreamFilter.java
@@ -32,4 +32,9 @@ public class StreamFilter {
     return new MessageStartEventSubscriptionStreamFilter(
         recordStreamSource.messageStartEventSubscriptionRecords());
   }
+
+  public static ProcessEventRecordStreamFilter processEventRecords(
+      final RecordStreamSource recordStreamSource) {
+    return new ProcessEventRecordStreamFilter(recordStreamSource.records());
+  }
 }

--- a/src/main/java/io/camunda/testing/utils/InspectionUtility.java
+++ b/src/main/java/io/camunda/testing/utils/InspectionUtility.java
@@ -1,6 +1,6 @@
 package io.camunda.testing.utils;
 
-import static io.camunda.testing.utils.RecordStreamManager.getRecordStreamSource;
+import static io.camunda.testing.utils.RecordStreamSourceStore.getRecordStreamSource;
 
 import io.camunda.testing.filters.StreamFilter;
 

--- a/src/main/java/io/camunda/testing/utils/InspectionUtility.java
+++ b/src/main/java/io/camunda/testing/utils/InspectionUtility.java
@@ -1,0 +1,12 @@
+package io.camunda.testing.utils;
+
+import static io.camunda.testing.utils.RecordStreamManager.getRecordStreamSource;
+
+import io.camunda.testing.filters.StreamFilter;
+
+public class InspectionUtility {
+
+  public static ProcessEventInspections findProcessEvents() {
+    return new ProcessEventInspections(StreamFilter.processEventRecords(getRecordStreamSource()));
+  }
+}

--- a/src/main/java/io/camunda/testing/utils/ProcessEventInspections.java
+++ b/src/main/java/io/camunda/testing/utils/ProcessEventInspections.java
@@ -1,0 +1,59 @@
+package io.camunda.testing.utils;
+
+import static io.camunda.testing.utils.RecordStreamManager.getRecordStreamSource;
+
+import io.camunda.testing.assertions.ProcessInstanceAssert;
+import io.camunda.testing.filters.ProcessEventRecordStreamFilter;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
+
+public class ProcessEventInspections {
+
+  private final ProcessEventRecordStreamFilter filter;
+
+  public ProcessEventInspections(final ProcessEventRecordStreamFilter filter) {
+    this.filter = filter;
+  }
+
+  public ProcessEventInspections triggeredByTimer(final String timerId) {
+    return new ProcessEventInspections(
+        filter.withIntent(ProcessEventIntent.TRIGGERED).withTargetElementId(timerId));
+  }
+
+  public ProcessEventInspections withProcessDefinitionKey(final long processDefinitionKey) {
+    return new ProcessEventInspections(filter.withProcessDefinitionKey(processDefinitionKey));
+  }
+
+  public ProcessInstanceAssert assertThatFirstProcessInstance() {
+    return assertThatProcessInstance(0);
+  }
+
+  public ProcessInstanceAssert assertThatLastProcessInstance() {
+    final List<Long> processInstanceKeys = getProcessInstanceKeys();
+    return assertThatProcessInstance(processInstanceKeys, processInstanceKeys.size() - 1);
+  }
+
+  public ProcessInstanceAssert assertThatProcessInstance(final int times) {
+    final List<Long> processInstanceKeys = getProcessInstanceKeys();
+    return assertThatProcessInstance(processInstanceKeys, times);
+  }
+
+  private ProcessInstanceAssert assertThatProcessInstance(final List<Long> keys, final int index) {
+    long processInstanceKey = -1;
+    try {
+      processInstanceKey = keys.get(index);
+    } catch (IndexOutOfBoundsException ex) {
+      Assertions.fail("No process instances have been found");
+    }
+    return new ProcessInstanceAssert(processInstanceKey, getRecordStreamSource());
+  }
+
+  private List<Long> getProcessInstanceKeys() {
+    return filter.stream()
+        .map(record -> record.getValue().getProcessInstanceKey())
+        .filter(record -> record != -1)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/io/camunda/testing/utils/ProcessEventInspections.java
+++ b/src/main/java/io/camunda/testing/utils/ProcessEventInspections.java
@@ -16,9 +16,10 @@ public class ProcessEventInspections {
   }
 
   /**
-   * Filters the process instances to only include instances that were triggered by a given timer id
+   * Filters the process instances to only include instances that were triggered by a given timer
+   * event id
    *
-   * @param timerId The id of the timer
+   * @param timerId The element ID of the timer event
    * @return this {@link ProcessEventInspections}
    */
   public ProcessEventInspections triggeredByTimer(final String timerId) {

--- a/src/main/java/io/camunda/testing/utils/RecordStreamManager.java
+++ b/src/main/java/io/camunda/testing/utils/RecordStreamManager.java
@@ -1,0 +1,25 @@
+package io.camunda.testing.utils;
+
+import org.camunda.community.eze.RecordStreamSource;
+
+public abstract class RecordStreamManager {
+
+  static ThreadLocal<RecordStreamSource> recordStreamSource = new ThreadLocal<>();
+
+  public static void init(final RecordStreamSource recordStreamSource) {
+    RecordStreamManager.recordStreamSource.set(recordStreamSource);
+  }
+
+  public static void reset() {
+    recordStreamSource.remove();
+  }
+
+  public static RecordStreamSource getRecordStreamSource() {
+    if (recordStreamSource.get() == null) {
+      throw new AssertionError(
+          "No RecordStreamSource is set. Please use @ZeebeAssertions extension and "
+              + "declare a RecordStreamSource field");
+    }
+    return recordStreamSource.get();
+  }
+}

--- a/src/main/java/io/camunda/testing/utils/RecordStreamSourceStore.java
+++ b/src/main/java/io/camunda/testing/utils/RecordStreamSourceStore.java
@@ -2,12 +2,12 @@ package io.camunda.testing.utils;
 
 import org.camunda.community.eze.RecordStreamSource;
 
-public abstract class RecordStreamManager {
+public abstract class RecordStreamSourceStore {
 
   static ThreadLocal<RecordStreamSource> recordStreamSource = new ThreadLocal<>();
 
   public static void init(final RecordStreamSource recordStreamSource) {
-    RecordStreamManager.recordStreamSource.set(recordStreamSource);
+    RecordStreamSourceStore.recordStreamSource.set(recordStreamSource);
   }
 
   public static void reset() {

--- a/src/main/java/io/camunda/testing/utils/model/InspectedProcessInstance.java
+++ b/src/main/java/io/camunda/testing/utils/model/InspectedProcessInstance.java
@@ -1,0 +1,14 @@
+package io.camunda.testing.utils.model;
+
+public class InspectedProcessInstance {
+
+  private final long processInstanceKey;
+
+  public InspectedProcessInstance(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+}

--- a/src/test/java/io/camunda/testing/util/Utilities.java
+++ b/src/test/java/io/camunda/testing/util/Utilities.java
@@ -44,6 +44,11 @@ public class Utilities {
     public static final String CORRELATION_KEY = "";
   }
 
+  public static final class ProcessPackTimerStartEvent {
+    public static final String RESOURCE_NAME = "timer-start-event-daily.bpmn";
+    public static final String TIMER_ID = "timer";
+  }
+
   public static DeploymentEvent deployProcess(final ZeebeClient client, final String process) {
     return deployProcesses(client, process);
   }

--- a/src/test/java/io/camunda/testing/utils/ProcessEventInspectionsTest.java
+++ b/src/test/java/io/camunda/testing/utils/ProcessEventInspectionsTest.java
@@ -1,0 +1,92 @@
+package io.camunda.testing.utils;
+
+import static io.camunda.testing.util.Utilities.deployProcess;
+import static io.camunda.testing.util.Utilities.increaseTime;
+import static io.camunda.testing.utils.InspectionUtility.findProcessEvents;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.testing.extensions.ZeebeAssertions;
+import io.camunda.testing.util.Utilities.ProcessPackTimerStartEvent;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import java.time.Duration;
+import org.camunda.community.eze.RecordStreamSource;
+import org.camunda.community.eze.ZeebeEngine;
+import org.camunda.community.eze.ZeebeEngineClock;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@ZeebeAssertions
+class ProcessEventInspectionsTest {
+
+  private static final String WRONG_TIMER_ID = "wrongtimer";
+
+  private ZeebeClient client;
+  private ZeebeEngine engine;
+  private ZeebeEngineClock clock;
+
+  @Nested
+  class HappyPathTests {
+
+    private RecordStreamSource recordStreamSource;
+
+    @Test
+    public void testAssertThatFirstProcessInstance() throws InterruptedException {
+      // given
+      final DeploymentEvent deploymentEvent =
+          deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
+
+      // when
+      increaseTime(clock, Duration.ofDays(1));
+
+      // then
+      findProcessEvents()
+          .triggeredByTimer(ProcessPackTimerStartEvent.TIMER_ID)
+          .withProcessDefinitionKey(deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
+          .assertThatFirstProcessInstance()
+          .isCompleted();
+    }
+
+    @Test
+    public void testAssertThatLastProcessInstance() throws InterruptedException {
+      // given
+      final DeploymentEvent deploymentEvent =
+          deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
+
+      // when
+      increaseTime(clock, Duration.ofDays(1));
+
+      // then
+      findProcessEvents()
+          .triggeredByTimer(ProcessPackTimerStartEvent.TIMER_ID)
+          .withProcessDefinitionKey(deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
+          .assertThatLastProcessInstance()
+          .isCompleted();
+    }
+  }
+
+  @Nested
+  class UnhappyPathTests {
+
+    private RecordStreamSource recordStreamSource;
+
+    @Test
+    public void testAssertThatFirstProcessInstance() throws InterruptedException {
+      // given
+      deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
+
+      // when
+      increaseTime(clock, Duration.ofDays(1));
+
+      // then
+      assertThatThrownBy(
+              () ->
+                  findProcessEvents()
+                      .triggeredByTimer(WRONG_TIMER_ID)
+                      .assertThatFirstProcessInstance()
+                      .isCompleted())
+          .isInstanceOf(AssertionError.class)
+          .hasMessage("No process instances have been found");
+    }
+  }
+}

--- a/src/test/java/io/camunda/testing/utils/ProcessEventInspectionsTest.java
+++ b/src/test/java/io/camunda/testing/utils/ProcessEventInspectionsTest.java
@@ -1,19 +1,21 @@
 package io.camunda.testing.utils;
 
+import static io.camunda.testing.assertions.BpmnAssert.assertThat;
+import static io.camunda.testing.utils.InspectionUtility.findProcessEvents;
 import static io.camunda.testing.util.Utilities.deployProcess;
 import static io.camunda.testing.util.Utilities.increaseTime;
-import static io.camunda.testing.utils.InspectionUtility.findProcessEvents;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.testing.extensions.ZeebeAssertions;
+import io.camunda.testing.utils.model.InspectedProcessInstance;
 import io.camunda.testing.util.Utilities.ProcessPackTimerStartEvent;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import java.time.Duration;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.camunda.community.eze.RecordStreamSource;
 import org.camunda.community.eze.ZeebeEngine;
 import org.camunda.community.eze.ZeebeEngineClock;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @ZeebeAssertions
@@ -24,69 +26,73 @@ class ProcessEventInspectionsTest {
   private ZeebeClient client;
   private ZeebeEngine engine;
   private ZeebeEngineClock clock;
+  private RecordStreamSource recordStreamSource;
 
-  @Nested
-  class HappyPathTests {
+  @Test
+  public void testFindFirstProcessInstance() throws InterruptedException {
+    // given
+    final DeploymentEvent deploymentEvent =
+        deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
-    private RecordStreamSource recordStreamSource;
+    // when
+    increaseTime(clock, Duration.ofDays(1));
+    final Optional<InspectedProcessInstance> firstProcessInstance =
+        findProcessEvents()
+            .triggeredByTimer(ProcessPackTimerStartEvent.TIMER_ID)
+            .withProcessDefinitionKey(
+                deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
+            .findFirstProcessInstance();
 
-    @Test
-    public void testAssertThatFirstProcessInstance() throws InterruptedException {
-      // given
-      final DeploymentEvent deploymentEvent =
-          deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
-
-      // when
-      increaseTime(clock, Duration.ofDays(1));
-
-      // then
-      findProcessEvents()
-          .triggeredByTimer(ProcessPackTimerStartEvent.TIMER_ID)
-          .withProcessDefinitionKey(deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
-          .assertThatFirstProcessInstance()
-          .isCompleted();
-    }
-
-    @Test
-    public void testAssertThatLastProcessInstance() throws InterruptedException {
-      // given
-      final DeploymentEvent deploymentEvent =
-          deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
-
-      // when
-      increaseTime(clock, Duration.ofDays(1));
-
-      // then
-      findProcessEvents()
-          .triggeredByTimer(ProcessPackTimerStartEvent.TIMER_ID)
-          .withProcessDefinitionKey(deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
-          .assertThatLastProcessInstance()
-          .isCompleted();
-    }
+    // then
+    Assertions.assertThat(firstProcessInstance).isNotEmpty();
+    assertThat(firstProcessInstance.get()).isCompleted();
   }
 
-  @Nested
-  class UnhappyPathTests {
+  @Test
+  public void testFindLastProcessInstance() throws InterruptedException {
+    // given
+    final DeploymentEvent deploymentEvent =
+        deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
-    private RecordStreamSource recordStreamSource;
+    // when
+    increaseTime(clock, Duration.ofDays(1));
+    final Optional<InspectedProcessInstance> lastProcessInstance =
+        findProcessEvents()
+            .triggeredByTimer(ProcessPackTimerStartEvent.TIMER_ID)
+            .withProcessDefinitionKey(
+                deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
+            .findLastProcessInstance();
 
-    @Test
-    public void testAssertThatFirstProcessInstance() throws InterruptedException {
-      // given
-      deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
+    // then
+    Assertions.assertThat(lastProcessInstance).isNotEmpty();
+    assertThat(lastProcessInstance.get()).isCompleted();
+  }
 
-      // when
-      increaseTime(clock, Duration.ofDays(1));
+  @Test
+  public void testFindFirstProcessInstance_wrongTimer() throws InterruptedException {
+    // given
+    deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
-      // then
-      assertThatThrownBy(
-              () ->
-                  findProcessEvents()
-                      .triggeredByTimer(WRONG_TIMER_ID)
-                      .assertThatFirstProcessInstance()
-                      .isCompleted())
-          .isInstanceOf(AssertionError.class)
-          .hasMessage("No process instances have been found");
-    }
+    // when
+    increaseTime(clock, Duration.ofDays(1));
+    final Optional<InspectedProcessInstance> processInstance =
+        findProcessEvents().triggeredByTimer(WRONG_TIMER_ID).findFirstProcessInstance();
+
+    // then
+    Assertions.assertThat(processInstance).isEmpty();
+  }
+
+  @Test
+  public void testFindProcessInstance_highIndex() throws InterruptedException {
+    // given
+    deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
+
+    // when
+    increaseTime(clock, Duration.ofDays(1));
+    final Optional<InspectedProcessInstance> processInstance =
+        findProcessEvents().findProcessInstance(10);
+
+    // then
+    Assertions.assertThat(processInstance).isEmpty();
   }
 }

--- a/src/test/resources/timer-start-event-daily.bpmn
+++ b/src/test/resources/timer-start-event-daily.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0wqnivx" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="timer-start-event-daily" isExecutable="true">
+    <bpmn:startEvent id="timer">
+      <bpmn:outgoing>Flow_0cilgmu</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_05dh8v1">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="endevent">
+      <bpmn:incoming>Flow_0cilgmu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0cilgmu" sourceRef="timer" targetRef="endevent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="timer-start-event-daily">
+      <bpmndi:BPMNEdge id="Flow_0cilgmu_di" bpmnElement="Flow_0cilgmu">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1v6zeun_di" bpmnElement="timer">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="122" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1nr1fux_di" bpmnElement="endevent">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

Timers don't need their own assertions. What we do need is a way to do assertions on a Process Instance once a timer start event has been triggered. This change allows for a route to the Process Instance assertions using the timer id.

I went with the option of using an `InspectionUtility`. There is unfortunately no obvious entry point for timers which could be used in `BpmnAssert`. The only thing we could use is a timer id, but an `assertThat(String)` method is in my opinion too generic. Another option would be choosing a different name for the assertion entry method in `BpmnAssert` so that we could use the timer id. It would result in something like: `assertThatProcessInstanceStartedByTimer(String timerId)` or something like that. This would be confusing in my opinion, as it seems like this will just do a single assertion, instead of returning the `ProcessInstanceAssertion` class.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10
relates to #46 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] The documentation is updated
