### PR TITLE
Make all utilities use waitForIdleState

### DIFF
--- a/src/test/java/io/camunda/testing/assertions/DeploymentAssertTest.java
+++ b/src/test/java/io/camunda/testing/assertions/DeploymentAssertTest.java
@@ -101,7 +101,8 @@ class DeploymentAssertTest {
     @Test
     public void testContainsProcessesByIdFailure() {
       // when
-      final DeploymentEvent deploymentEvent = deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
+      final DeploymentEvent deploymentEvent =
+          deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // then
       assertThatThrownBy(
@@ -113,7 +114,8 @@ class DeploymentAssertTest {
     @Test
     public void testContainsProcessesByResourceNameFailure() {
       // when
-      final DeploymentEvent deploymentEvent = deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
+      final DeploymentEvent deploymentEvent =
+          deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // then
       assertThatThrownBy(

--- a/src/test/java/io/camunda/testing/assertions/IncidentAssertTest.java
+++ b/src/test/java/io/camunda/testing/assertions/IncidentAssertTest.java
@@ -36,10 +36,10 @@ class IncidentAssertTest {
     private ZeebeClient client;
 
     @Test
-    void testHasErrorType() throws InterruptedException {
+    void testHasErrorType() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -60,10 +60,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testHasErrorMessage() throws InterruptedException {
+    void testHasErrorMessage() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -85,10 +85,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testExtractErrorMessage() throws InterruptedException {
+    void testExtractErrorMessage() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -113,11 +113,11 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testWasRaisedInProcessInstance() throws InterruptedException {
+    void testWasRaisedInProcessInstance() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent processInstanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -139,7 +139,7 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testOccurredOnElement() throws InterruptedException {
+    void testOccurredOnElement() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -149,7 +149,7 @@ class IncidentAssertTest {
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
       /* will raise an incident in the gateway because VAR_TOTAL_LOOPS is a string, but needs to be an int */
       final ActivateJobsResponse jobActivationResponse =
           activateSingleJob(client, ProcessPackLoopingServiceTask.JOB_TYPE);
@@ -165,10 +165,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testOccurredDuringJob() throws InterruptedException {
+    void testOccurredDuringJob() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -190,10 +190,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testIsResolved() throws InterruptedException {
+    void testIsResolved() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -219,10 +219,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testIsUnresolved() throws InterruptedException {
+    void testIsUnresolved() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -250,10 +250,10 @@ class IncidentAssertTest {
     private ZeebeClient client;
 
     @Test
-    void testHasErrorTypeFailure() throws InterruptedException {
+    void testHasErrorTypeFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -277,10 +277,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testHasErrorMessageFailure() throws InterruptedException {
+    void testHasErrorMessageFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -304,11 +304,11 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testWasRaisedInProcessInstanceFailure() throws InterruptedException {
+    void testWasRaisedInProcessInstanceFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent processInstanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -333,7 +333,7 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testOccurredOnElementFailure() throws InterruptedException {
+    void testOccurredOnElementFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -343,7 +343,7 @@ class IncidentAssertTest {
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
       /* will raise an incident in the gateway because VAR_TOTAL_LOOPS is a string, but needs to be an int */
       final ActivateJobsResponse jobActivationResponse =
           activateSingleJob(client, ProcessPackLoopingServiceTask.JOB_TYPE);
@@ -363,10 +363,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testOccurredDuringJobFailure() throws InterruptedException {
+    void testOccurredDuringJobFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -391,10 +391,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testIsResolvedFailure() throws InterruptedException {
+    void testIsResolvedFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -417,10 +417,10 @@ class IncidentAssertTest {
     }
 
     @Test
-    void testIsUnresolvedFailure() throws InterruptedException {
+    void testIsUnresolvedFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =

--- a/src/test/java/io/camunda/testing/assertions/JobAssertTest.java
+++ b/src/test/java/io/camunda/testing/assertions/JobAssertTest.java
@@ -37,12 +37,12 @@ class JobAssertTest {
     private RecordStreamSource recordStreamSource;
 
     @Test
-    void testHasElementId() throws InterruptedException {
+    void testHasElementId() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -54,12 +54,12 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasDeadline() throws InterruptedException {
+    void testHasDeadline() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final long expectedDeadline = System.currentTimeMillis() + 100;
@@ -78,12 +78,12 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasBpmnProcessId() throws InterruptedException {
+    void testHasBpmnProcessId() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -95,12 +95,12 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasRetries() throws InterruptedException {
+    void testHasRetries() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -112,10 +112,10 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasAnyIncidents() throws InterruptedException {
+    void testHasAnyIncidents() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      Utilities.startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -135,10 +135,10 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasNoIncidents() throws InterruptedException {
+    void testHasNoIncidents() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      Utilities.startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -150,10 +150,10 @@ class JobAssertTest {
     }
 
     @Test
-    void testExtractLatestIncident() throws InterruptedException {
+    void testExtractLatestIncident() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      Utilities.startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -178,12 +178,12 @@ class JobAssertTest {
     }
 
     @Test
-    void testExtractingVariables() throws InterruptedException {
+    void testExtractingVariables() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -198,12 +198,12 @@ class JobAssertTest {
     }
 
     @Test
-    void testExtractingHeaders() throws InterruptedException {
+    void testExtractingHeaders() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -222,12 +222,12 @@ class JobAssertTest {
     private ZeebeClient client;
 
     @Test
-    void testHasElementIdFailure() throws InterruptedException {
+    void testHasElementIdFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -244,12 +244,12 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasDeadlineFailure() throws InterruptedException {
+    void testHasDeadlineFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final long expectedDeadline = System.currentTimeMillis() + 100;
@@ -270,12 +270,12 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasBpmnProcessIdFailure() throws InterruptedException {
+    void testHasBpmnProcessIdFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -292,12 +292,12 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasRetriesFailure() throws InterruptedException {
+    void testHasRetriesFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
           Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -313,10 +313,10 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasAnyIncidentsFailure() throws InterruptedException {
+    void testHasAnyIncidentsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      Utilities.startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -330,10 +330,10 @@ class JobAssertTest {
     }
 
     @Test
-    void testHasNoIncidentsFailure() throws InterruptedException {
+    void testHasNoIncidentsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      Utilities.startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =
@@ -353,10 +353,10 @@ class JobAssertTest {
     }
 
     @Test
-    void testExtractLatestIncidentFailure() throws InterruptedException {
+    void testExtractLatestIncidentFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      Utilities.startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // when
       final ActivateJobsResponse jobActivationResponse =

--- a/src/test/java/io/camunda/testing/assertions/ProcessAssertTest.java
+++ b/src/test/java/io/camunda/testing/assertions/ProcessAssertTest.java
@@ -74,13 +74,13 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasAnyInstances() throws InterruptedException {
+    public void testHasAnyInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       final ProcessAssert processAssert =
           assertThat(deploymentEvent)
@@ -106,14 +106,14 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasInstances() throws InterruptedException {
+    public void testHasInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       final ProcessAssert processAssert =
           assertThat(deploymentEvent)
@@ -204,13 +204,13 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasNoInstances() throws InterruptedException {
+    public void testHasNoInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       final ProcessAssert processAssert =
           assertThat(deploymentEvent)
@@ -223,15 +223,15 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasInstances() throws InterruptedException {
+    public void testHasInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       final ProcessAssert processAssert =
           assertThat(deploymentEvent)

--- a/src/test/java/io/camunda/testing/assertions/ProcessInstanceAssertTest.java
+++ b/src/test/java/io/camunda/testing/assertions/ProcessInstanceAssertTest.java
@@ -39,43 +39,43 @@ class ProcessInstanceAssertTest {
     private ZeebeClient client;
 
     @Test
-    public void testProcessInstanceIsStarted() throws InterruptedException {
+    public void testProcessInstanceIsStarted() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // then
       assertThat(instanceEvent).isStarted();
     }
 
     @Test
-    public void testProcessInstanceIsActive() throws InterruptedException {
+    public void testProcessInstanceIsActive() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // then
       assertThat(instanceEvent).isActive();
     }
 
     @Test
-    public void testProcessInstanceIsCompleted() throws InterruptedException {
+    public void testProcessInstanceIsCompleted() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
@@ -85,28 +85,28 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotCompleted() throws InterruptedException {
+    public void testProcessInstanceIsNotCompleted() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // then
       assertThat(instanceEvent).isNotCompleted();
     }
 
     @Test
-    public void testProcessInstanceIsTerminated() throws InterruptedException {
+    public void testProcessInstanceIsTerminated() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       client.newCancelInstanceCommand(instanceEvent.getProcessInstanceKey()).send().join();
@@ -117,28 +117,28 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotTerminated() throws InterruptedException {
+    public void testProcessInstanceIsNotTerminated() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // then
       assertThat(instanceEvent).isNotTerminated();
     }
 
     @Test
-    public void testProcessInstanceHasPassedElement() throws InterruptedException {
+    public void testProcessInstanceHasPassedElement() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
@@ -148,29 +148,29 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasNotPassedElement() throws InterruptedException {
+    public void testProcessInstanceHasNotPassedElement() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // then
       assertThat(instanceEvent).hasNotPassedElement(ProcessPackLoopingServiceTask.ELEMENT_ID);
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementMultipleTimes() throws InterruptedException {
+    public void testProcessInstanceHasPassedElementMultipleTimes() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final int totalLoops = 5;
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, totalLoops);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, totalLoops);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       for (int i = 0; i < 5; i++) {
@@ -178,61 +178,66 @@ class ProcessInstanceAssertTest {
       }
 
       // then
-      assertThat(instanceEvent).hasPassedElement(ProcessPackLoopingServiceTask.ELEMENT_ID,
-          totalLoops);
+      assertThat(instanceEvent)
+          .hasPassedElement(ProcessPackLoopingServiceTask.ELEMENT_ID, totalLoops);
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementsInOrder() throws InterruptedException {
+    public void testProcessInstanceHasPassedElementsInOrder() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
 
       // then
-      assertThat(instanceEvent).hasPassedElementInOrder(
-          ProcessPackLoopingServiceTask.START_EVENT_ID, ProcessPackLoopingServiceTask.ELEMENT_ID,
-          ProcessPackLoopingServiceTask.END_EVENT_ID);
+      assertThat(instanceEvent)
+          .hasPassedElementInOrder(
+              ProcessPackLoopingServiceTask.START_EVENT_ID,
+              ProcessPackLoopingServiceTask.ELEMENT_ID,
+              ProcessPackLoopingServiceTask.END_EVENT_ID);
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAt() throws InterruptedException {
+    public void testProcessInstanceIsWaitingAt() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // then
       assertThat(instanceEvent).isWaitingAtElement(ProcessPackMultipleTasks.ELEMENT_ID_1);
     }
 
     @Test
-    public void testProcessIsWaitingAtMultipleElements() throws InterruptedException {
+    public void testProcessIsWaitingAtMultipleElements() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // then
-      assertThat(instanceEvent).isWaitingAtElement(ProcessPackMultipleTasks.ELEMENT_ID_1,
-          ProcessPackMultipleTasks.ELEMENT_ID_2, ProcessPackMultipleTasks.ELEMENT_ID_3);
+      assertThat(instanceEvent)
+          .isWaitingAtElement(
+              ProcessPackMultipleTasks.ELEMENT_ID_1,
+              ProcessPackMultipleTasks.ELEMENT_ID_2,
+              ProcessPackMultipleTasks.ELEMENT_ID_3);
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAt() throws InterruptedException {
+    public void testProcessInstanceIsNotWaitingAt() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // when
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_1);
@@ -242,11 +247,11 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtMulitpleElements() throws InterruptedException {
+    public void testProcessInstanceIsNotWaitingAtMulitpleElements() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // when
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_1);
@@ -254,16 +259,19 @@ class ProcessInstanceAssertTest {
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_3);
 
       // then
-      assertThat(instanceEvent).isNotWaitingAtElement(ProcessPackMultipleTasks.ELEMENT_ID_1,
-          ProcessPackMultipleTasks.ELEMENT_ID_2, ProcessPackMultipleTasks.ELEMENT_ID_3);
+      assertThat(instanceEvent)
+          .isNotWaitingAtElement(
+              ProcessPackMultipleTasks.ELEMENT_ID_1,
+              ProcessPackMultipleTasks.ELEMENT_ID_2,
+              ProcessPackMultipleTasks.ELEMENT_ID_3);
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtNonExistingElement() throws InterruptedException {
+    public void testProcessInstanceIsNotWaitingAtNonExistingElement() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
       final String nonExistingElementId = "non-existing-task";
 
       // when
@@ -274,22 +282,23 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElements() throws InterruptedException {
+    public void testProcessInstanceIsWaitingExactlyAtElements() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // when
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_1);
 
       // then
-      assertThat(instanceEvent).isWaitingExactlyAtElements(ProcessPackMultipleTasks.ELEMENT_ID_2,
-          ProcessPackMultipleTasks.ELEMENT_ID_3);
+      assertThat(instanceEvent)
+          .isWaitingExactlyAtElements(
+              ProcessPackMultipleTasks.ELEMENT_ID_2, ProcessPackMultipleTasks.ELEMENT_ID_3);
     }
 
     @Test
-    public void testProcessInstanceIsWaitingForMessage() throws InterruptedException {
+    public void testProcessInstanceIsWaitingForMessage() {
       // given
       deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -297,55 +306,55 @@ class ProcessInstanceAssertTest {
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMessageEvent.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackMessageEvent.PROCESS_ID, variables);
 
       // then
       assertThat(instanceEvent).isWaitingForMessage(ProcessPackMessageEvent.MESSAGE_NAME);
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingForMessage() throws InterruptedException {
+    public void testProcessInstanceIsNotWaitingForMessage() {
       // given
       deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
       final Map<String, Object> variables =
-          Collections.singletonMap(ProcessPackMessageEvent.CORRELATION_KEY_VARIABLE,
-              correlationKey);
+          Collections.singletonMap(
+              ProcessPackMessageEvent.CORRELATION_KEY_VARIABLE, correlationKey);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMessageEvent.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackMessageEvent.PROCESS_ID, variables);
 
       // when
-      sendMessage(client, ProcessPackMessageEvent.MESSAGE_NAME, correlationKey);
+      sendMessage(engine, client, ProcessPackMessageEvent.MESSAGE_NAME, correlationKey);
 
       // then
       assertThat(instanceEvent).isNotWaitingForMessage(ProcessPackMessageEvent.MESSAGE_NAME);
     }
 
     @Test
-    public void testProcessInstanceHasVariable() throws InterruptedException {
+    public void testProcessInstanceHasVariable() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // then
       assertThat(instanceEvent).hasVariable(ProcessPackLoopingServiceTask.TOTAL_LOOPS);
     }
 
     @Test
-    public void testProcessInstanceHasVariableWithValue() throws InterruptedException {
+    public void testProcessInstanceHasVariableWithValue() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, "1");
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, "1");
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // then
       assertThat(instanceEvent)
@@ -353,52 +362,52 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByName() throws InterruptedException {
+    public void testHasCorrelatedMessageByName() {
       // given
       deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
       final Map<String, Object> variables =
           Collections.singletonMap("correlationKey", correlationKey);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMessageEvent.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackMessageEvent.PROCESS_ID, variables);
 
       // when
-      sendMessage(client, ProcessPackMessageEvent.MESSAGE_NAME, correlationKey);
+      sendMessage(engine, client, ProcessPackMessageEvent.MESSAGE_NAME, correlationKey);
 
       // then
       assertThat(instanceEvent).hasCorrelatedMessageByName(ProcessPackMessageEvent.MESSAGE_NAME, 1);
     }
 
     @Test
-    public void testHasCorrelatedMessageByCorrelationKey() throws InterruptedException {
+    public void testHasCorrelatedMessageByCorrelationKey() {
       // given
       deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
       final Map<String, Object> variables =
-          Collections.singletonMap(ProcessPackMessageEvent.CORRELATION_KEY_VARIABLE,
-              correlationKey);
+          Collections.singletonMap(
+              ProcessPackMessageEvent.CORRELATION_KEY_VARIABLE, correlationKey);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMessageEvent.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackMessageEvent.PROCESS_ID, variables);
 
       // when
-      sendMessage(client, ProcessPackMessageEvent.MESSAGE_NAME, correlationKey);
+      sendMessage(engine, client, ProcessPackMessageEvent.MESSAGE_NAME, correlationKey);
 
       // then
       assertThat(instanceEvent).hasCorrelatedMessageByCorrelationKey(correlationKey, 1);
     }
 
     @Test
-    public void testHasAnyIncidents() throws InterruptedException {
+    public void testHasAnyIncidents() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       final Map<String, Object> variables =
-          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS,
-              "invalid value"); // will cause incident
+          Collections.singletonMap(
+              ProcessPackLoopingServiceTask.TOTAL_LOOPS, "invalid value"); // will cause incident
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
       /* will raise an incident in the gateway because ProcessPackLoopingServiceTask.TOTAL_LOOPS is a string, but needs to be an int */
       completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
 
@@ -407,30 +416,30 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasNoIncidents() throws InterruptedException {
+    public void testHasNoIncidents() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // then
       assertThat(instanceEvent).hasNoIncidents();
     }
 
     @Test
-    public void testExtractLatestIncident() throws InterruptedException {
+    public void testExtractLatestIncident() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       final Map<String, Object> variables =
-          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS,
-              "invalid value"); // will cause incident
+          Collections.singletonMap(
+              ProcessPackLoopingServiceTask.TOTAL_LOOPS, "invalid value"); // will cause incident
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
       /* will raise an incident in the gateway because ProcessPackLoopingServiceTask.TOTAL_LOOPS is a string, but needs to be an int */
       completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
 
@@ -470,11 +479,10 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotStartedIfProcessInstanceKeyNoMatch()
-        throws InterruptedException {
+    public void testProcessInstanceIsNotStartedIfProcessInstanceKeyNoMatch() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+      startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
       final ProcessInstanceEvent mockInstanceEvent = mock(ProcessInstanceEvent.class);
 
       // when
@@ -487,12 +495,14 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsActiveFailure() throws InterruptedException {
+    public void testProcessInstanceIsActiveFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
           startProcessInstance(
-              client, ProcessPackLoopingServiceTask.PROCESS_ID,
+              engine,
+              client,
+              ProcessPackLoopingServiceTask.PROCESS_ID,
               Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1));
 
       // when
@@ -505,13 +515,16 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsCompletedFailure() throws InterruptedException {
+    public void testProcessInstanceIsCompletedFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID,
+          startProcessInstance(
+              engine,
+              client,
+              ProcessPackLoopingServiceTask.PROCESS_ID,
               Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1));
 
       // then
@@ -522,11 +535,14 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotCompletedFailure() throws InterruptedException {
+    public void testProcessInstanceIsNotCompletedFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID,
+          startProcessInstance(
+              engine,
+              client,
+              ProcessPackLoopingServiceTask.PROCESS_ID,
               Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1));
 
       // when
@@ -539,13 +555,16 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsTerminatedFailure() throws InterruptedException {
+    public void testProcessInstanceIsTerminatedFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID,
+          startProcessInstance(
+              engine,
+              client,
+              ProcessPackLoopingServiceTask.PROCESS_ID,
               Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1));
 
       // then
@@ -556,11 +575,14 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotTerminatedFailure() throws InterruptedException {
+    public void testProcessInstanceIsNotTerminatedFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID,
+          startProcessInstance(
+              engine,
+              client,
+              ProcessPackLoopingServiceTask.PROCESS_ID,
               Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1));
 
       // when
@@ -574,62 +596,74 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementFailure() throws InterruptedException {
+    public void testProcessInstanceHasPassedElementFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID,
+          startProcessInstance(
+              engine,
+              client,
+              ProcessPackLoopingServiceTask.PROCESS_ID,
               Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1));
 
       // then
-      assertThatThrownBy(() -> assertThat(instanceEvent).hasPassedElement(
-          ProcessPackLoopingServiceTask.ELEMENT_ID))
+      assertThatThrownBy(
+              () ->
+                  assertThat(instanceEvent)
+                      .hasPassedElement(ProcessPackLoopingServiceTask.ELEMENT_ID))
           .isInstanceOf(AssertionError.class)
-          .hasMessage("Expected element with id %s to be passed 1 times",
+          .hasMessage(
+              "Expected element with id %s to be passed 1 times",
               ProcessPackLoopingServiceTask.ELEMENT_ID);
     }
 
     @Test
-    public void testProcessInstanceHasNotPassedElementFailure() throws InterruptedException {
+    public void testProcessInstanceHasNotPassedElementFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID,
+          startProcessInstance(
+              engine,
+              client,
+              ProcessPackLoopingServiceTask.PROCESS_ID,
               Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1));
-
-      // when
-      completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
-
-      // then
-      assertThatThrownBy(() -> assertThat(instanceEvent).hasNotPassedElement(
-          ProcessPackLoopingServiceTask.ELEMENT_ID))
-          .isInstanceOf(AssertionError.class)
-          .hasMessage("Expected element with id %s to be passed 0 times",
-              ProcessPackLoopingServiceTask.ELEMENT_ID);
-    }
-
-    @Test
-    public void testProcessInstanceHasPassedElementsInOrderFailure() throws InterruptedException {
-      // given
-      deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
-      final Map<String, Object> variables = Collections.singletonMap(
-          ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
-      final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // when
       completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
 
       // then
       assertThatThrownBy(
-          () ->
-              assertThat(instanceEvent)
-                  .hasPassedElementInOrder(
-                      ProcessPackLoopingServiceTask.END_EVENT_ID,
-                      ProcessPackLoopingServiceTask.ELEMENT_ID,
-                      ProcessPackLoopingServiceTask.START_EVENT_ID))
+              () ->
+                  assertThat(instanceEvent)
+                      .hasNotPassedElement(ProcessPackLoopingServiceTask.ELEMENT_ID))
+          .isInstanceOf(AssertionError.class)
+          .hasMessage(
+              "Expected element with id %s to be passed 0 times",
+              ProcessPackLoopingServiceTask.ELEMENT_ID);
+    }
+
+    @Test
+    public void testProcessInstanceHasPassedElementsInOrderFailure() {
+      // given
+      deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
+      final Map<String, Object> variables =
+          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 1);
+      final ProcessInstanceEvent instanceEvent =
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+
+      // when
+      completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
+
+      // then
+      assertThatThrownBy(
+              () ->
+                  assertThat(instanceEvent)
+                      .hasPassedElementInOrder(
+                          ProcessPackLoopingServiceTask.END_EVENT_ID,
+                          ProcessPackLoopingServiceTask.ELEMENT_ID,
+                          ProcessPackLoopingServiceTask.START_EVENT_ID))
           .isInstanceOf(AssertionError.class)
           .hasMessage(
               "[Ordered elements] \n"
@@ -638,29 +672,30 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAtFailure() throws InterruptedException {
+    public void testProcessInstanceIsWaitingAtFailure() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // when
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_1);
 
       // then
       assertThatThrownBy(
-          () -> assertThat(instanceEvent).isWaitingAtElement(ProcessPackMultipleTasks.ELEMENT_ID_1))
+              () ->
+                  assertThat(instanceEvent)
+                      .isWaitingAtElement(ProcessPackMultipleTasks.ELEMENT_ID_1))
           .isInstanceOf(AssertionError.class)
           .hasMessageContainingAll("to contain", ProcessPackMultipleTasks.ELEMENT_ID_1);
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAtMultipleElementsFailure()
-        throws InterruptedException {
+    public void testProcessInstanceIsWaitingAtMultipleElementsFailure() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // when
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_1);
@@ -669,24 +704,26 @@ class ProcessInstanceAssertTest {
 
       // then
       assertThatThrownBy(
-          () ->
-              assertThat(instanceEvent)
-                  .isWaitingAtElement(
-                      ProcessPackMultipleTasks.ELEMENT_ID_1,
-                      ProcessPackMultipleTasks.ELEMENT_ID_2,
-                      ProcessPackMultipleTasks.ELEMENT_ID_3))
+              () ->
+                  assertThat(instanceEvent)
+                      .isWaitingAtElement(
+                          ProcessPackMultipleTasks.ELEMENT_ID_1,
+                          ProcessPackMultipleTasks.ELEMENT_ID_2,
+                          ProcessPackMultipleTasks.ELEMENT_ID_3))
           .isInstanceOf(AssertionError.class)
-          .hasMessageContainingAll("to contain:", ProcessPackMultipleTasks.ELEMENT_ID_1,
-              ProcessPackMultipleTasks.ELEMENT_ID_2, ProcessPackMultipleTasks.ELEMENT_ID_3);
+          .hasMessageContainingAll(
+              "to contain:",
+              ProcessPackMultipleTasks.ELEMENT_ID_1,
+              ProcessPackMultipleTasks.ELEMENT_ID_2,
+              ProcessPackMultipleTasks.ELEMENT_ID_3);
     }
 
     @Test
-    public void testProcessInstanceWaitingAtNonExistingElementFailure()
-        throws InterruptedException {
+    public void testProcessInstanceWaitingAtNonExistingElementFailure() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
       final String nonExistingTaskId = "non-existing-task";
 
       // when
@@ -699,57 +736,62 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtFailure() throws InterruptedException {
+    public void testProcessInstanceIsNotWaitingAtFailure() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // then
-      assertThatThrownBy(() -> assertThat(instanceEvent)
-          .isNotWaitingAtElement(ProcessPackMultipleTasks.ELEMENT_ID_1))
+      assertThatThrownBy(
+              () ->
+                  assertThat(instanceEvent)
+                      .isNotWaitingAtElement(ProcessPackMultipleTasks.ELEMENT_ID_1))
           .isInstanceOf(AssertionError.class)
           .hasMessageContainingAll("not to contain", ProcessPackMultipleTasks.ELEMENT_ID_1);
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtMulitpleElementsFailure()
-        throws InterruptedException {
+    public void testProcessInstanceIsNotWaitingAtMulitpleElementsFailure() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // then
       assertThatThrownBy(
-          () ->
-              assertThat(instanceEvent)
-                  .isNotWaitingAtElement(
-                      ProcessPackMultipleTasks.ELEMENT_ID_1,
-                      ProcessPackMultipleTasks.ELEMENT_ID_2,
-                      ProcessPackMultipleTasks.ELEMENT_ID_3))
+              () ->
+                  assertThat(instanceEvent)
+                      .isNotWaitingAtElement(
+                          ProcessPackMultipleTasks.ELEMENT_ID_1,
+                          ProcessPackMultipleTasks.ELEMENT_ID_2,
+                          ProcessPackMultipleTasks.ELEMENT_ID_3))
           .isInstanceOf(AssertionError.class)
-          .hasMessageContainingAll("not to contain", ProcessPackMultipleTasks.ELEMENT_ID_1,
-              ProcessPackMultipleTasks.ELEMENT_ID_2, ProcessPackMultipleTasks.ELEMENT_ID_3);
+          .hasMessageContainingAll(
+              "not to contain",
+              ProcessPackMultipleTasks.ELEMENT_ID_1,
+              ProcessPackMultipleTasks.ELEMENT_ID_2,
+              ProcessPackMultipleTasks.ELEMENT_ID_3);
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooManyElements()
-        throws InterruptedException {
+    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooManyElements() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
 
       // then
-      assertThatThrownBy(() -> assertThat(instanceEvent).isWaitingExactlyAtElements(
-          ProcessPackMultipleTasks.ELEMENT_ID_1))
+      assertThatThrownBy(
+              () ->
+                  assertThat(instanceEvent)
+                      .isWaitingExactlyAtElements(ProcessPackMultipleTasks.ELEMENT_ID_1))
           .isInstanceOf(AssertionError.class)
           .hasMessageContainingAll(
               String.format(
@@ -761,25 +803,24 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooLittleElements()
-        throws InterruptedException {
+    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooLittleElements() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_1);
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_2);
 
       // then
       assertThatThrownBy(
-          () ->
-              assertThat(instanceEvent)
-                  .isWaitingExactlyAtElements(
-                      ProcessPackMultipleTasks.ELEMENT_ID_1,
-                      ProcessPackMultipleTasks.ELEMENT_ID_2,
-                      ProcessPackMultipleTasks.ELEMENT_ID_3))
+              () ->
+                  assertThat(instanceEvent)
+                      .isWaitingExactlyAtElements(
+                          ProcessPackMultipleTasks.ELEMENT_ID_1,
+                          ProcessPackMultipleTasks.ELEMENT_ID_2,
+                          ProcessPackMultipleTasks.ELEMENT_ID_3))
           .isInstanceOf(AssertionError.class)
           .hasMessageContainingAll(
               String.format(
@@ -791,24 +832,23 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_combination()
-        throws InterruptedException {
+    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_combination() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMultipleTasks.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_1);
       completeTask(engine, client, ProcessPackMultipleTasks.ELEMENT_ID_2);
 
       // then
       assertThatThrownBy(
-          () ->
-              assertThat(instanceEvent)
-                  .isWaitingExactlyAtElements(
-                      ProcessPackMultipleTasks.ELEMENT_ID_1,
-                      ProcessPackMultipleTasks.ELEMENT_ID_2))
+              () ->
+                  assertThat(instanceEvent)
+                      .isWaitingExactlyAtElements(
+                          ProcessPackMultipleTasks.ELEMENT_ID_1,
+                          ProcessPackMultipleTasks.ELEMENT_ID_2))
           .isInstanceOf(AssertionError.class)
           .hasMessageContainingAll(
               String.format(
@@ -823,27 +863,29 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingForMessageFailure() throws InterruptedException {
+    public void testProcessInstanceIsWaitingForMessageFailure() {
       // given
       deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
       final Map<String, Object> variables =
           Collections.singletonMap("correlationKey", correlationKey);
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMessageEvent.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackMessageEvent.PROCESS_ID, variables);
 
       // when
-      sendMessage(client, ProcessPackMessageEvent.MESSAGE_NAME, correlationKey);
+      sendMessage(engine, client, ProcessPackMessageEvent.MESSAGE_NAME, correlationKey);
 
       // then
       assertThatThrownBy(
-          () -> assertThat(instanceEvent).isWaitingForMessage(ProcessPackMessageEvent.MESSAGE_NAME))
+              () ->
+                  assertThat(instanceEvent)
+                      .isWaitingForMessage(ProcessPackMessageEvent.MESSAGE_NAME))
           .isInstanceOf(AssertionError.class)
           .hasMessageContainingAll("to contain:", ProcessPackMessageEvent.MESSAGE_NAME);
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingForMessageFailure() throws InterruptedException {
+    public void testProcessInstanceIsNotWaitingForMessageFailure() {
       // given
       deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -852,25 +894,27 @@ class ProcessInstanceAssertTest {
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMessageEvent.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackMessageEvent.PROCESS_ID, variables);
 
       // then
-      assertThatThrownBy(() -> assertThat(instanceEvent).isNotWaitingForMessage(
-          ProcessPackMessageEvent.MESSAGE_NAME))
+      assertThatThrownBy(
+              () ->
+                  assertThat(instanceEvent)
+                      .isNotWaitingForMessage(ProcessPackMessageEvent.MESSAGE_NAME))
           .isInstanceOf(AssertionError.class)
           .hasMessageContainingAll("not to contain", ProcessPackMessageEvent.MESSAGE_NAME);
     }
 
     @Test
-    public void testProcessInstanceHasVariableFailure() throws InterruptedException {
+    public void testProcessInstanceHasVariableFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final String expectedVariable = "variable";
       final String actualVariable = "loopAmount";
 
       // when
-      final ProcessInstanceEvent instanceEvent = startProcessInstance(client,
-          ProcessPackLoopingServiceTask.PROCESS_ID);
+      final ProcessInstanceEvent instanceEvent =
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // then
       assertThatThrownBy(() -> assertThat(instanceEvent).hasVariable(expectedVariable))
@@ -881,7 +925,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariableWithValueFailure() throws InterruptedException {
+    public void testProcessInstanceHasVariableWithValueFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final String variable = "variable";
@@ -891,11 +935,11 @@ class ProcessInstanceAssertTest {
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
 
       // then
       assertThatThrownBy(
-          () -> assertThat(instanceEvent).hasVariableWithValue(variable, expectedValue))
+              () -> assertThat(instanceEvent).hasVariableWithValue(variable, expectedValue))
           .isInstanceOf(AssertionError.class)
           .hasMessage(
               "The variable '%s' does not have the expected value. The value passed in"
@@ -905,7 +949,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByNameFailure() throws InterruptedException {
+    public void testHasCorrelatedMessageByNameFailure() {
       // given
       deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -914,12 +958,13 @@ class ProcessInstanceAssertTest {
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMessageEvent.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackMessageEvent.PROCESS_ID, variables);
 
       // then
       assertThatThrownBy(
-          () -> assertThat(instanceEvent).hasCorrelatedMessageByName(
-              ProcessPackMessageEvent.MESSAGE_NAME, 1))
+              () ->
+                  assertThat(instanceEvent)
+                      .hasCorrelatedMessageByName(ProcessPackMessageEvent.MESSAGE_NAME, 1))
           .isInstanceOf(AssertionError.class)
           .hasMessage(
               "Expected message with name '%s' to be correlated %d times, but was %d times",
@@ -927,7 +972,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByCorrelationKeyFailure() throws InterruptedException {
+    public void testHasCorrelatedMessageByCorrelationKeyFailure() {
       // given
       deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -936,11 +981,12 @@ class ProcessInstanceAssertTest {
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackMessageEvent.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackMessageEvent.PROCESS_ID, variables);
 
       // then
       assertThatThrownBy(
-          () -> assertThat(instanceEvent).hasCorrelatedMessageByCorrelationKey(correlationKey, 1))
+              () ->
+                  assertThat(instanceEvent).hasCorrelatedMessageByCorrelationKey(correlationKey, 1))
           .isInstanceOf(AssertionError.class)
           .hasMessage(
               "Expected message with correlation key '%s' to be correlated %d "
@@ -949,13 +995,13 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasAnyIncidentsFailure() throws InterruptedException {
+    public void testHasAnyIncidentsFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // then
       assertThatThrownBy(() -> assertThat(instanceEvent).hasAnyIncidents())
@@ -964,16 +1010,16 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasNoIncidentsFailure() throws InterruptedException {
+    public void testHasNoIncidentsFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
-          Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS,
-              "invalid value"); // will cause incident
+          Collections.singletonMap(
+              ProcessPackLoopingServiceTask.TOTAL_LOOPS, "invalid value"); // will cause incident
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
       /* will raise an incident in the gateway because ProcessPackLoopingServiceTask.TOTAL_LOOPS is a string, but needs to be an int */
       completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
 
@@ -984,13 +1030,13 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testExtractLatestIncidentFailure() throws InterruptedException {
+    public void testExtractLatestIncidentFailure() {
       // given
       deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
       // when
       final ProcessInstanceEvent instanceEvent =
-          startProcessInstance(client, ProcessPackLoopingServiceTask.PROCESS_ID);
+          startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // then
       assertThatThrownBy(() -> assertThat(instanceEvent).extractLatestIncident())

--- a/src/test/java/io/camunda/testing/utils/ProcessEventInspectionsTest.java
+++ b/src/test/java/io/camunda/testing/utils/ProcessEventInspectionsTest.java
@@ -1,13 +1,13 @@
 package io.camunda.testing.utils;
 
 import static io.camunda.testing.assertions.BpmnAssert.assertThat;
-import static io.camunda.testing.utils.InspectionUtility.findProcessEvents;
 import static io.camunda.testing.util.Utilities.deployProcess;
 import static io.camunda.testing.util.Utilities.increaseTime;
+import static io.camunda.testing.utils.InspectionUtility.findProcessEvents;
 
 import io.camunda.testing.extensions.ZeebeAssertions;
-import io.camunda.testing.utils.model.InspectedProcessInstance;
 import io.camunda.testing.util.Utilities.ProcessPackTimerStartEvent;
+import io.camunda.testing.utils.model.InspectedProcessInstance;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import java.time.Duration;
@@ -29,13 +29,13 @@ class ProcessEventInspectionsTest {
   private RecordStreamSource recordStreamSource;
 
   @Test
-  public void testFindFirstProcessInstance() throws InterruptedException {
+  public void testFindFirstProcessInstance() {
     // given
     final DeploymentEvent deploymentEvent =
         deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
     // when
-    increaseTime(clock, Duration.ofDays(1));
+    increaseTime(engine, Duration.ofDays(1));
     final Optional<InspectedProcessInstance> firstProcessInstance =
         findProcessEvents()
             .triggeredByTimer(ProcessPackTimerStartEvent.TIMER_ID)
@@ -49,13 +49,13 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindLastProcessInstance() throws InterruptedException {
+  public void testFindLastProcessInstance() {
     // given
     final DeploymentEvent deploymentEvent =
         deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
     // when
-    increaseTime(clock, Duration.ofDays(1));
+    increaseTime(engine, Duration.ofDays(1));
     final Optional<InspectedProcessInstance> lastProcessInstance =
         findProcessEvents()
             .triggeredByTimer(ProcessPackTimerStartEvent.TIMER_ID)
@@ -69,12 +69,12 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindFirstProcessInstance_wrongTimer() throws InterruptedException {
+  public void testFindFirstProcessInstance_wrongTimer() {
     // given
     deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
     // when
-    increaseTime(clock, Duration.ofDays(1));
+    increaseTime(engine, Duration.ofDays(1));
     final Optional<InspectedProcessInstance> processInstance =
         findProcessEvents().triggeredByTimer(WRONG_TIMER_ID).findFirstProcessInstance();
 
@@ -83,12 +83,12 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindProcessInstance_highIndex() throws InterruptedException {
+  public void testFindProcessInstance_highIndex() {
     // given
     deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
     // when
-    increaseTime(clock, Duration.ofDays(1));
+    increaseTime(engine, Duration.ofDays(1));
     final Optional<InspectedProcessInstance> processInstance =
         findProcessEvents().findProcessInstance(10);
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This makes sure `waitForIdleState()` is the only place where we still do a `Thread.sleep()`. Having this isolated makes it easier to remove it once we've implemented a way to wait for an idle state in the engine.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
