### PR TITLE
feat: Deploy snapshot version to artifactory

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -14,8 +14,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Cache
         uses: actions/cache@v2
         with:
@@ -23,6 +26,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Set up Java environment
         uses: actions/setup-java@v2.3.1
         with:
@@ -30,9 +34,11 @@ jobs:
           java-version: 11
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
+
       - name: Build
         id: build
         run: mvn -B -U -Dsurefire.rerunFailingTestsCount=5 clean install
+
       - name: Archive Test Results on Failure
         uses: actions/upload-artifact@v2
         if: failure()
@@ -40,27 +46,43 @@ jobs:
           name: test-results
           path: target/surefire-reports/
           retention-days: 7
+
       - name: Publish Unit Test Results
         id: publish
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: failure()
         with:
           files: target/surefire-reports/*.xml
-      - if: github.event.release || github.event_name == 'workflow_dispatch'
-        name: Deploy SNAPSHOT / Release
+
+      - name: Import Secrets
+        if: github.event.release || github.event_name == 'workflow_dispatch'
+        id: secrets
+        uses: hashicorp/vault-action@v2.1.1
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/common/github.com/actions/camunda-cloud/camunda-cloud-testing ARTIFACTS_USR;
+            secret/data/common/github.com/actions/camunda-cloud/camunda-cloud-testing ARTIFACTS_PSW;
+
+      - name: Deploy SNAPSHOT / Release
+        if: github.event.release || github.event_name == 'workflow_dispatch'
+        id: release
         uses: camunda-community-hub/community-action-maven-release@v1
         with:
           release-version: ${{ github.event.release.tag_name }}
           release-profile: community-action-maven-release
-          nexus-usr: ${{ secrets.NEXUS_USR }}
-          nexus-psw: ${{ secrets.NEXUS_PSW }}
-          maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
-          maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
-          maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
+          nexus-usr: ${{ steps.secrets.outputs.ARTIFACTS_USR }}
+          nexus-psw: ${{ steps.secrets.outputs.ARTIFACTS_PSW }}
+          maven-usr: dummy
+          maven-psw: dummy
+          maven-gpg-passphrase: dummy
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        id: release
-      - if: github.event.release
-        name: Attach artifacts to GitHub Release (Release only)
+
+      - name: Attach artifacts to GitHub Release (Release only)
+        if: github.event.release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.camunda.community</groupId>
+    <artifactId>community-hub-release-parent</artifactId>
+    <version>1.2.2</version>
+  </parent>
+
   <groupId>io.camunda</groupId>
-  <artifactId>camunda-cloud-testing</artifactId>
+  <artifactId>zeebe-bpmn-assert</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>Camunda Cloud Testing</name>
+  <name>Zeebe BPMN Assert</name>
 
   <scm>
     <connection>scm:git:git@github.com:camunda-cloud/camunda-cloud-testing.git</connection>
@@ -33,6 +39,11 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
 
+    <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io</nexus.release.repository>
+    <nexus.release.repository.id>camunda-nexus</nexus.release.repository.id>
+    <nexus.snapshot.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots</nexus.snapshot.repository>
+    <nexus.snapshot.repository.id>camunda-nexus</nexus.snapshot.repository.id>
+
     <plugin.version.fmt>2.9.1</plugin.version.fmt>
     <plugin.version.googlejavaformat>1.12.0</plugin.version.googlejavaformat>
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
@@ -40,6 +51,8 @@
     <plugin.version.maven-enforcer>3.0.0</plugin.version.maven-enforcer>
     <plugin.version.spotless>2.17.4</plugin.version.spotless>
     <plugin.version.surefire>3.0.0-M5</plugin.version.surefire>
+
+    <version.java>11</version.java>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
- Add import secrets step in pipeline to get the secrets out of Hashicorp vault
- Snapshots can be published by triggering the GitHub action manually.
- Use the community-action-maven-release GitHub action to deploy a snapshot version to artifactory. This action also makes it possible to release to maven central, for now the maven credentials have been filled with dummy values. Nothing should be pushed to maven central yet. **This will cause the pipeline to fail when you want to deploy a SNAPSHOT**, however the SNAPSHOT will still publish to Artifactory. It might be somewhat confusing, but I figured it would be fine to get an initial SNAPSHOT out there so we could gather feedback.
- Use the community-hub-release-parent pom. This is required for the community release action. To make sure the artifacts land in the correct repository we needed to override some properties from the parent pom.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #25 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
