### PR TITLE
Inspect Call Activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ Optional<InspectedProcessInstance> firstProcessInstance = InspectionUtility.find
 ProcessInstanceAssert assertions = BpmnAssert.assertThat(firstProcessInstance.get());
 ```
 
+Started by a call activity:
+```java
+Optional<InspectedProcessInstance> firstProcessInstance = InspectionUtility.findProcessInstances()
+  .withParentProcessInstanceKey(<key>)
+  .withBpmnProcessId("<called process id>")
+  .findFirstProcessInstance();
+ProcessInstanceAssert assertions = BpmnAssert.assertThat(firstProcessInstance.get());
+```
+
 #### Job Assertions
 ```java
 ActivateJobsResponse response = client.newActivateJobsCommand()

--- a/src/main/java/io/camunda/testing/filters/ProcessInstanceRecordStreamFilter.java
+++ b/src/main/java/io/camunda/testing/filters/ProcessInstanceRecordStreamFilter.java
@@ -65,8 +65,7 @@ public class ProcessInstanceRecordStreamFilter {
       final long parentProcessInstanceKey) {
     return new ProcessInstanceRecordStreamFilter(
         stream.filter(
-            record -> record.getValue().getParentProcessInstanceKey() == parentProcessInstanceKey)
-    );
+            record -> record.getValue().getParentProcessInstanceKey() == parentProcessInstanceKey));
   }
 
   public ProcessInstanceRecordStreamFilter withBpmnProcessId(final String bpmnProcessId) {

--- a/src/main/java/io/camunda/testing/filters/ProcessInstanceRecordStreamFilter.java
+++ b/src/main/java/io/camunda/testing/filters/ProcessInstanceRecordStreamFilter.java
@@ -61,6 +61,19 @@ public class ProcessInstanceRecordStreamFilter {
         stream.filter(record -> record.getRejectionType() == rejectionType));
   }
 
+  public ProcessInstanceRecordStreamFilter withParentProcessInstanceKey(
+      final long parentProcessInstanceKey) {
+    return new ProcessInstanceRecordStreamFilter(
+        stream.filter(
+            record -> record.getValue().getParentProcessInstanceKey() == parentProcessInstanceKey)
+    );
+  }
+
+  public ProcessInstanceRecordStreamFilter withBpmnProcessId(final String bpmnProcessId) {
+    return new ProcessInstanceRecordStreamFilter(
+        stream.filter(record -> record.getValue().getBpmnProcessId().equals(bpmnProcessId)));
+  }
+
   public Stream<Record<ProcessInstanceRecordValue>> stream() {
     return stream;
   }

--- a/src/main/java/io/camunda/testing/utils/InspectionUtility.java
+++ b/src/main/java/io/camunda/testing/utils/InspectionUtility.java
@@ -9,4 +9,8 @@ public class InspectionUtility {
   public static ProcessEventInspections findProcessEvents() {
     return new ProcessEventInspections(StreamFilter.processEventRecords(getRecordStreamSource()));
   }
+
+  public static ProcessInstanceInspections findProcessInstances() {
+    return new ProcessInstanceInspections(StreamFilter.processInstance(getRecordStreamSource()));
+  }
 }

--- a/src/main/java/io/camunda/testing/utils/ProcessInstanceInspections.java
+++ b/src/main/java/io/camunda/testing/utils/ProcessInstanceInspections.java
@@ -1,0 +1,101 @@
+package io.camunda.testing.utils;
+
+import io.camunda.testing.filters.ProcessInstanceRecordStreamFilter;
+import io.camunda.testing.utils.model.InspectedProcessInstance;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class ProcessInstanceInspections {
+
+  private final ProcessInstanceRecordStreamFilter filter;
+
+  public ProcessInstanceInspections(final ProcessInstanceRecordStreamFilter filter) {
+    this.filter = filter;
+  }
+
+
+  /**
+   * Filters the process instances to only include instances that were started by the given parent
+   * process instance key
+   *
+   * @param key The key of the parent process instance
+   * @return this {@link ProcessInstanceInspections}
+   */
+  public ProcessInstanceInspections startedByProcessInstance(final long key) {
+    return new ProcessInstanceInspections(filter.withParentProcessInstanceKey(key));
+  }
+
+  /**
+   * Filters the process instances to only include instances that have the given BPMN process id
+   *
+   * @param bpmnProcessId The BPMN process id of the desired process instance
+   * @return this {@link ProcessInstanceInspections}
+   */
+  public ProcessInstanceInspections withBpmnProcessId(final String bpmnProcessId) {
+    return new ProcessInstanceInspections(filter.withBpmnProcessId(bpmnProcessId));
+  }
+
+  /**
+   * Finds the first process instance that matches the applied filters
+   *
+   * @return {@link Optional} of {@link InspectedProcessInstance}
+   */
+  public Optional<InspectedProcessInstance> findFirstProcessInstance() {
+    return findProcessInstance(0);
+  }
+
+  /**
+   * Finds the last process instance that matches the applied filters
+   *
+   * @return {@link Optional} of {@link InspectedProcessInstance}
+   */
+  public Optional<InspectedProcessInstance> findLastProcessInstance() {
+    final List<Long> processInstanceKeys = getProcessInstanceKeys();
+    return findProcessInstance(processInstanceKeys, processInstanceKeys.size() - 1);
+  }
+
+  /**
+   * Finds the process instance that matches the applied filters at a given index
+   *
+   * <p>Example: If 3 process instances have been started, findProcessInstance(1) would return the
+   * second started instance.
+   *
+   * @param index The index of the process instance start at 0
+   * @return {@link Optional} of {@link InspectedProcessInstance}
+   */
+  public Optional<InspectedProcessInstance> findProcessInstance(final int index) {
+    final List<Long> processInstanceKeys = getProcessInstanceKeys();
+    return findProcessInstance(processInstanceKeys, index);
+  }
+
+  /**
+   * Gets the given index from a list of process instance keys uses it to create an {@link
+   * InspectedProcessInstance}
+   *
+   * @param keys The list of process instance key
+   * @param index The desired index
+   * @return {@link Optional} of {@link InspectedProcessInstance}
+   */
+  private Optional<InspectedProcessInstance> findProcessInstance(
+      final List<Long> keys, final int index) {
+    try {
+      final long processInstanceKey = keys.get(index);
+      return Optional.of(new InspectedProcessInstance(processInstanceKey));
+    } catch (IndexOutOfBoundsException ex) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Maps the filtered stream to a list of process instance keys
+   *
+   * @return List of process instance keys
+   */
+  private List<Long> getProcessInstanceKeys() {
+    return filter.stream()
+        .map(record -> record.getValue().getProcessInstanceKey())
+        .filter(record -> record != -1)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/io/camunda/testing/utils/ProcessInstanceInspections.java
+++ b/src/main/java/io/camunda/testing/utils/ProcessInstanceInspections.java
@@ -21,7 +21,7 @@ public class ProcessInstanceInspections {
    * @param key The key of the parent process instance
    * @return this {@link ProcessInstanceInspections}
    */
-  public ProcessInstanceInspections startedByProcessInstance(final long key) {
+  public ProcessInstanceInspections withParentProcessInstanceKey(final long key) {
     return new ProcessInstanceInspections(filter.withParentProcessInstanceKey(key));
   }
 

--- a/src/main/java/io/camunda/testing/utils/ProcessInstanceInspections.java
+++ b/src/main/java/io/camunda/testing/utils/ProcessInstanceInspections.java
@@ -14,7 +14,6 @@ public class ProcessInstanceInspections {
     this.filter = filter;
   }
 
-
   /**
    * Filters the process instances to only include instances that were started by the given parent
    * process instance key

--- a/src/test/java/io/camunda/testing/util/Utilities.java
+++ b/src/test/java/io/camunda/testing/util/Utilities.java
@@ -55,6 +55,13 @@ public class Utilities {
     public static final String TIMER_ID = "timer";
   }
 
+  public static final class ProcessPackCallActivity {
+    public static final String RESOURCE_NAME = "call-activity.bpmn";
+    public static final String PROCESS_ID = "call-activity";
+    public static final String CALLED_RESOURCE_NAME = "start-end.bpmn";
+    public static final String CALLED_PROCESS_ID = "start-end";
+  }
+
   public static DeploymentEvent deployProcess(final ZeebeClient client, final String process) {
     return deployProcesses(client, process);
   }

--- a/src/test/java/io/camunda/testing/util/Utilities.java
+++ b/src/test/java/io/camunda/testing/util/Utilities.java
@@ -58,6 +58,7 @@ public class Utilities {
   public static final class ProcessPackCallActivity {
     public static final String RESOURCE_NAME = "call-activity.bpmn";
     public static final String PROCESS_ID = "call-activity";
+    public static final String CALL_ACTIVITY_ID = "callactivity";
     public static final String CALLED_RESOURCE_NAME = "start-end.bpmn";
     public static final String CALLED_PROCESS_ID = "start-end";
   }

--- a/src/test/java/io/camunda/testing/utils/ProcessInstanceInspectionsTest.java
+++ b/src/test/java/io/camunda/testing/utils/ProcessInstanceInspectionsTest.java
@@ -1,7 +1,6 @@
 package io.camunda.testing.utils;
 
 import static io.camunda.testing.assertions.BpmnAssert.assertThat;
-import static io.camunda.testing.util.Utilities.deployProcess;
 import static io.camunda.testing.util.Utilities.deployProcesses;
 import static io.camunda.testing.util.Utilities.startProcessInstance;
 import static io.camunda.testing.utils.InspectionUtility.findProcessInstances;
@@ -27,16 +26,19 @@ public class ProcessInstanceInspectionsTest {
   @Test
   public void testStartedByProcessInstanceWithProcessId() {
     // given
-    deployProcesses(client, ProcessPackCallActivity.RESOURCE_NAME,
+    deployProcesses(
+        client,
+        ProcessPackCallActivity.RESOURCE_NAME,
         ProcessPackCallActivity.CALLED_RESOURCE_NAME);
     final ProcessInstanceEvent instanceEvent =
         startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
 
     // when
     final Optional<InspectedProcessInstance> firstProcessInstance =
-        findProcessInstances().startedByProcessInstance(instanceEvent.getProcessInstanceKey())
-        .withBpmnProcessId(ProcessPackCallActivity.CALLED_PROCESS_ID)
-        .findFirstProcessInstance();
+        findProcessInstances()
+            .startedByProcessInstance(instanceEvent.getProcessInstanceKey())
+            .withBpmnProcessId(ProcessPackCallActivity.CALLED_PROCESS_ID)
+            .findFirstProcessInstance();
 
     // then
     Assertions.assertThat(firstProcessInstance).isNotEmpty();
@@ -49,14 +51,17 @@ public class ProcessInstanceInspectionsTest {
   @Test
   public void testStartedByProcessInstanceWithProcessId_wrongId() {
     // given
-    deployProcesses(client, ProcessPackCallActivity.RESOURCE_NAME,
+    deployProcesses(
+        client,
+        ProcessPackCallActivity.RESOURCE_NAME,
         ProcessPackCallActivity.CALLED_RESOURCE_NAME);
     final ProcessInstanceEvent instanceEvent =
         startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
 
     // when
     final Optional<InspectedProcessInstance> firstProcessInstance =
-        findProcessInstances().startedByProcessInstance(instanceEvent.getProcessInstanceKey())
+        findProcessInstances()
+            .startedByProcessInstance(instanceEvent.getProcessInstanceKey())
             .withBpmnProcessId("wrongId")
             .findFirstProcessInstance();
 

--- a/src/test/java/io/camunda/testing/utils/ProcessInstanceInspectionsTest.java
+++ b/src/test/java/io/camunda/testing/utils/ProcessInstanceInspectionsTest.java
@@ -1,0 +1,66 @@
+package io.camunda.testing.utils;
+
+import static io.camunda.testing.assertions.BpmnAssert.assertThat;
+import static io.camunda.testing.util.Utilities.deployProcess;
+import static io.camunda.testing.util.Utilities.deployProcesses;
+import static io.camunda.testing.util.Utilities.startProcessInstance;
+import static io.camunda.testing.utils.InspectionUtility.findProcessInstances;
+
+import io.camunda.testing.extensions.ZeebeAssertions;
+import io.camunda.testing.util.Utilities.ProcessPackCallActivity;
+import io.camunda.testing.utils.model.InspectedProcessInstance;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.camunda.community.eze.RecordStreamSource;
+import org.camunda.community.eze.ZeebeEngine;
+import org.junit.jupiter.api.Test;
+
+@ZeebeAssertions
+public class ProcessInstanceInspectionsTest {
+
+  private ZeebeClient client;
+  private ZeebeEngine engine;
+  private RecordStreamSource recordStreamSource;
+
+  @Test
+  public void testStartedByProcessInstanceWithProcessId() {
+    // given
+    deployProcesses(client, ProcessPackCallActivity.RESOURCE_NAME,
+        ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+    final ProcessInstanceEvent instanceEvent =
+        startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+    // when
+    final Optional<InspectedProcessInstance> firstProcessInstance =
+        findProcessInstances().startedByProcessInstance(instanceEvent.getProcessInstanceKey())
+        .withBpmnProcessId(ProcessPackCallActivity.CALLED_PROCESS_ID)
+        .findFirstProcessInstance();
+
+    // then
+    Assertions.assertThat(firstProcessInstance).isNotEmpty();
+    assertThat(firstProcessInstance.get()).isCompleted();
+    assertThat(instanceEvent)
+        .hasPassedElement(ProcessPackCallActivity.CALL_ACTIVITY_ID)
+        .isCompleted();
+  }
+
+  @Test
+  public void testStartedByProcessInstanceWithProcessId_wrongId() {
+    // given
+    deployProcesses(client, ProcessPackCallActivity.RESOURCE_NAME,
+        ProcessPackCallActivity.CALLED_RESOURCE_NAME);
+    final ProcessInstanceEvent instanceEvent =
+        startProcessInstance(engine, client, ProcessPackCallActivity.PROCESS_ID);
+
+    // when
+    final Optional<InspectedProcessInstance> firstProcessInstance =
+        findProcessInstances().startedByProcessInstance(instanceEvent.getProcessInstanceKey())
+            .withBpmnProcessId("wrongId")
+            .findFirstProcessInstance();
+
+    // then
+    Assertions.assertThat(firstProcessInstance).isEmpty();
+  }
+}

--- a/src/test/java/io/camunda/testing/utils/ProcessInstanceInspectionsTest.java
+++ b/src/test/java/io/camunda/testing/utils/ProcessInstanceInspectionsTest.java
@@ -36,7 +36,7 @@ public class ProcessInstanceInspectionsTest {
     // when
     final Optional<InspectedProcessInstance> firstProcessInstance =
         findProcessInstances()
-            .startedByProcessInstance(instanceEvent.getProcessInstanceKey())
+            .withParentProcessInstanceKey(instanceEvent.getProcessInstanceKey())
             .withBpmnProcessId(ProcessPackCallActivity.CALLED_PROCESS_ID)
             .findFirstProcessInstance();
 
@@ -61,7 +61,7 @@ public class ProcessInstanceInspectionsTest {
     // when
     final Optional<InspectedProcessInstance> firstProcessInstance =
         findProcessInstances()
-            .startedByProcessInstance(instanceEvent.getProcessInstanceKey())
+            .withParentProcessInstanceKey(instanceEvent.getProcessInstanceKey())
             .withBpmnProcessId("wrongId")
             .findFirstProcessInstance();
 

--- a/src/test/resources/call-activity.bpmn
+++ b/src/test/resources/call-activity.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1j49vx1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="call-activity" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1oizqpb</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1oizqpb" sourceRef="StartEvent_1" targetRef="callactivity" />
+    <bpmn:callActivity id="callactivity">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="start-end" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1oizqpb</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ytr5rb</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1w612bd">
+      <bpmn:incoming>Flow_0ytr5rb</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ytr5rb" sourceRef="callactivity" targetRef="Event_1w612bd" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="call-activity">
+      <bpmndi:BPMNEdge id="Flow_1oizqpb_di" bpmnElement="Flow_1oizqpb">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ytr5rb_di" bpmnElement="Flow_0ytr5rb">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x2fflk_di" bpmnElement="callactivity">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1w612bd_di" bpmnElement="Event_1w612bd">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/resources/start-end.bpmn
+++ b/src/test/resources/start-end.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_03pj5sg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="start-end" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0puuckb</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0ahcnkn">
+      <bpmn:incoming>Flow_0puuckb</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0puuckb" sourceRef="StartEvent_1" targetRef="Event_0ahcnkn" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="start-end">
+      <bpmndi:BPMNEdge id="Flow_0puuckb_di" bpmnElement="Flow_0puuckb">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ahcnkn_di" bpmnElement="Event_0ahcnkn">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When a process instance is started by a Call Activity element, there is no entry point for the assertions. This makes it impossible to test these process instances. With this change I've introduces a `ProcessInstanceInspections` class which will make it possible to find these process instances and assert over them.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #46 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [x] Javadoc has been written
* [ ] The documentation is updated
