### PR TITLE
Improve assert on variables - String -> Object

### DIFF
--- a/src/main/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssert.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssert.java
@@ -457,7 +457,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    * Assert that the given variable name is a key in the given map of variables.
    *
    * <p>This assertion has been extracted from the method ${@link #hasVariable(String)} so that the
-   * method ${@link #hasVariableWithValue(String, String)} could reuse it without having to traverse
+   * method ${@link #hasVariableWithValue(String, Object)} could reuse it without having to traverse
    * the record stream to collect the variables a second time.
    *
    * @param name The name of the variable
@@ -481,7 +481,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    * @param value The value of the variable
    * @return this ${@link ProcessInstanceAssert}
    */
-  public ProcessInstanceAssert hasVariableWithValue(final String name, final String value) {
+  public ProcessInstanceAssert hasVariableWithValue(final String name, final Object value) {
     final ZeebeObjectMapper mapper = new ZeebeObjectMapper();
     final String mappedValue = mapper.toJson(value);
     final Map<String, String> variables = getProcessInstanceVariables();
@@ -499,7 +499,8 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
   }
 
   /**
-   * Returns a Map of variables that belong to this process instance
+   * Returns a Map of variables that belong to this process instance. The values in that map are
+   * JSON Strings
    *
    * @return map of variables
    */


### PR DESCRIPTION
## Description
Change signature to assert on Objects instead of Strings
Also extend tests to check it against variables of different types

## Related issues

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
