### PR TITLE
Switch to our own in memory engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ The following details are due to the project being in early stages of developmen
 * Works only in JUnit 5 (we might stick to that, but are happy to receive feedback)
 * Zeebe is an asynchronous engine, so use `Thread.sleep(100)` to wait for Zeebe to process the last request (in the
   future we want to offer a method to wait for Zeebe to become idle)
-* You need to inject the following fields in your tests to make the extension work:
+* The extension can inject the following fields into your test:
 
 ```java
-
-@ZeebeAssertions
+@ZeebeProcessTest
 class DeploymentAssertTest {
 
   private ZeebeClient client;

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
     <dependency.osgi.version>4.3.1</dependency.osgi.version>
     <dependency.protobuf.version>3.19.1</dependency.protobuf.version>
     <dependency.scala.version>2.13.7</dependency.scala.version>
-    <dependency.log4j.version>2.14.1</dependency.log4j.version>
     <dependency.slf4j.version>1.7.32</dependency.slf4j.version>
     <dependency.snakeyaml.version>1.29</dependency.snakeyaml.version>
     <dependency.spring.version>5.3.10</dependency.spring.version>
@@ -211,7 +210,6 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${dependency.log4j.version}</version>
     </dependency>
-
 
     <!-- Test scope-->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,15 +27,23 @@
     <dependency.awaitility.version>4.1.1</dependency.awaitility.version>
     <dependency.errorprone.version>2.10.0</dependency.errorprone.version>
     <dependency.eze.version>0.6.0</dependency.eze.version>
+    <dependency.findbugs.version>3.0.2</dependency.findbugs.version>
     <dependency.guava.version>31.0.1-jre</dependency.guava.version>
     <dependency.jackson.version>2.13.0</dependency.jackson.version>
     <dependency.jna.version>5.10.0</dependency.jna.version>
     <dependency.junit.version>5.8.2</dependency.junit.version>
+    <dependency.junit4.version>4.13.2</dependency.junit4.version>
+    <dependency.log4j.version>2.14.1</dependency.log4j.version>
     <dependency.mockito.version>4.1.0</dependency.mockito.version>
     <dependency.netty.version>4.1.70.Final</dependency.netty.version>
+    <dependency.osgi.version>4.3.1</dependency.osgi.version>
     <dependency.protobuf.version>3.19.1</dependency.protobuf.version>
     <dependency.scala.version>2.13.7</dependency.scala.version>
+    <dependency.log4j.version>2.14.1</dependency.log4j.version>
     <dependency.slf4j.version>1.7.32</dependency.slf4j.version>
+    <dependency.snakeyaml.version>1.29</dependency.snakeyaml.version>
+    <dependency.spring.version>5.3.10</dependency.spring.version>
+    <dependency.zeebe.version>1.2.4</dependency.zeebe.version>
 
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
@@ -72,6 +80,14 @@
         <version>${dependency.assertj.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-bom</artifactId>
+        <version>${dependency.zeebe.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- Only for dependency convergence issues -->
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -87,11 +103,6 @@
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
         <version>${dependency.jna.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${dependency.slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>
@@ -120,7 +131,34 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <version>${dependency.junit4.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>${dependency.findbugs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.core</artifactId>
+        <version>${dependency.osgi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${dependency.spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${dependency.slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${dependency.snakeyaml.version}</version>
       </dependency>
 
       <!-- Test scope-->
@@ -137,15 +175,44 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
+
     <dependency>
-      <groupId>org.camunda.community</groupId>
-      <artifactId>eze-junit-extension</artifactId>
-      <version>${dependency.eze.version}</version>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-workflow-engine</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-logstreams</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${dependency.log4j.version}</version>
+    </dependency>
+
+
     <!-- Test scope-->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/io/camunda/zeebe/bpmnassert/RecordStreamSourceStore.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/RecordStreamSourceStore.java
@@ -1,6 +1,6 @@
 package io.camunda.zeebe.bpmnassert;
 
-import org.camunda.community.eze.RecordStreamSource;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 
 public abstract class RecordStreamSourceStore {
 

--- a/src/main/java/io/camunda/zeebe/bpmnassert/assertions/DeploymentAssert.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/assertions/DeploymentAssert.java
@@ -3,11 +3,11 @@ package io.camunda.zeebe.bpmnassert.assertions;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.Process;
 import java.util.List;
 import org.assertj.core.api.AbstractAssert;
-import org.camunda.community.eze.RecordStreamSource;
 
 /** Assertions for {@code DeploymentEvent} instances */
 public class DeploymentAssert extends AbstractAssert<DeploymentAssert, DeploymentEvent> {

--- a/src/main/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssert.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssert.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.util.Optional;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.StringAssert;
-import org.jetbrains.annotations.NotNull;
 
 /** Assertions for incidents. An incident is identified by its incident key. */
 public class IncidentAssert extends AbstractAssert<IncidentAssert, Long> {
@@ -215,7 +214,6 @@ public class IncidentAssert extends AbstractAssert<IncidentAssert, Long> {
     return optIncidentCreatedRecord.get().getValue();
   }
 
-  @NotNull
   private Optional<Record<IncidentRecordValue>> findIncidentCreatedRecord() {
     return getIncidentRecords(IncidentIntent.CREATED).stream().findFirst();
   }

--- a/src/main/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssert.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssert.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.bpmnassert.filters.IncidentRecordStreamFilter;
 import io.camunda.zeebe.bpmnassert.filters.StreamFilter;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.protocol.record.Record;
@@ -14,7 +15,6 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.util.Optional;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.StringAssert;
-import org.camunda.community.eze.RecordStreamSource;
 import org.jetbrains.annotations.NotNull;
 
 /** Assertions for incidents. An incident is identified by its incident key. */

--- a/src/main/java/io/camunda/zeebe/bpmnassert/assertions/JobAssert.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/assertions/JobAssert.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.bpmnassert.filters.IncidentRecordStreamFilter;
 import io.camunda.zeebe.bpmnassert.filters.StreamFilter;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -13,7 +14,6 @@ import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.data.Offset;
-import org.camunda.community.eze.RecordStreamSource;
 
 /** Assertions for {@code ActivatedJob} instances */
 public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {

--- a/src/main/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssert.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssert.java
@@ -3,6 +3,7 @@ package io.camunda.zeebe.bpmnassert.assertions;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.camunda.zeebe.bpmnassert.filters.StreamFilter;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -16,7 +17,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
-import org.camunda.community.eze.RecordStreamSource;
 
 public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageResponse> {
 

--- a/src/main/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssert.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssert.java
@@ -3,6 +3,7 @@ package io.camunda.zeebe.bpmnassert.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.bpmnassert.filters.StreamFilter;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.api.response.Process;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -13,7 +14,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.AbstractAssert;
-import org.camunda.community.eze.RecordStreamSource;
 
 /**
  * Assertions for {@code Process} instances.

--- a/src/main/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssert.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssert.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.bpmnassert.filters.IncidentRecordStreamFilter;
 import io.camunda.zeebe.bpmnassert.filters.StreamFilter;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -18,7 +19,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.SoftAssertions;
-import org.camunda.community.eze.RecordStreamSource;
 
 public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert, Long> {
 

--- a/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertions.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertions.java
@@ -5,12 +5,10 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.camunda.community.eze.EmbeddedZeebeEngine;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@EmbeddedZeebeEngine
 @ExtendWith(ZeebeAssertionsExtension.class)
 public @interface ZeebeAssertions {}

--- a/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertionsExtension.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertionsExtension.java
@@ -13,9 +13,11 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.platform.commons.util.ReflectionUtils;
 
-public class ZeebeAssertionsExtension implements BeforeEachCallback, AfterEachCallback {
+public class ZeebeAssertionsExtension implements BeforeEachCallback, AfterEachCallback,
+    TestWatcher {
 
   private static final String KEY_ZEEBE_CLIENT = "ZEEBE_CLIENT";
   private static final String KEY_ZEEBE_ENGINE = "ZEEBE_ENGINE";
@@ -45,6 +47,15 @@ public class ZeebeAssertionsExtension implements BeforeEachCallback, AfterEachCa
     final Object engineContent = getStore(extensionContext).get(KEY_ZEEBE_ENGINE);
     final InMemoryEngine engine = (InMemoryEngine) engineContent;
     engine.stop();
+  }
+
+  @Override
+  public void testFailed(final ExtensionContext extensionContext, final Throwable cause) {
+    final Object engineContent = getStore(extensionContext).get(KEY_ZEEBE_ENGINE);
+    final InMemoryEngine engine = (InMemoryEngine) engineContent;
+
+    System.out.println("===== Test failed! Printing records from the stream:");
+    engine.getRecordStream().print(true);
   }
 
   private void injectFields(final ExtensionContext extensionContext, final Object... objects) {

--- a/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertionsExtension.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertionsExtension.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.platform.commons.util.ReflectionUtils;
 
-public class ZeebeAssertionsExtension implements BeforeEachCallback, AfterEachCallback,
-    TestWatcher {
+public class ZeebeAssertionsExtension
+    implements BeforeEachCallback, AfterEachCallback, TestWatcher {
 
   private static final String KEY_ZEEBE_CLIENT = "ZEEBE_CLIENT";
   private static final String KEY_ZEEBE_ENGINE = "ZEEBE_ENGINE";

--- a/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeProcessTest.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeProcessTest.java
@@ -10,5 +10,5 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@ExtendWith(ZeebeAssertionsExtension.class)
-public @interface ZeebeAssertions {}
+@ExtendWith(ZeebeProcessTestExtension.class)
+public @interface ZeebeProcessTest {}

--- a/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeProcessTestExtension.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeProcessTestExtension.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.platform.commons.util.ReflectionUtils;
 
-public class ZeebeAssertionsExtension
+public class ZeebeProcessTestExtension
     implements BeforeEachCallback, AfterEachCallback, TestWatcher {
 
   private static final String KEY_ZEEBE_CLIENT = "ZEEBE_CLIENT";
@@ -90,8 +90,7 @@ public class ZeebeAssertionsExtension
       ReflectionUtils.makeAccessible(field);
       field.set(extensionContext.getRequiredTestInstance(), object);
     } catch (IllegalAccessException e) {
-      // TODO proper error handling
-      e.printStackTrace();
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/io/camunda/zeebe/bpmnassert/filters/JobRecordStreamFilter.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/filters/JobRecordStreamFilter.java
@@ -26,6 +26,11 @@ public class JobRecordStreamFilter {
     return new JobRecordStreamFilter(stream.filter(record -> record.getIntent() == intent));
   }
 
+  public JobRecordStreamFilter withElementId(final String elementId) {
+    return new JobRecordStreamFilter(
+        stream.filter(record -> record.getValue().getElementId().equals(elementId)));
+  }
+
   public Stream<Record<JobRecordValue>> stream() {
     return stream;
   }

--- a/src/main/java/io/camunda/zeebe/bpmnassert/filters/StreamFilter.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/filters/StreamFilter.java
@@ -1,6 +1,6 @@
 package io.camunda.zeebe.bpmnassert.filters;
 
-import org.camunda.community.eze.RecordStreamSource;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 
 public class StreamFilter {
 

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/EngineFactory.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/EngineFactory.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class EngineFactory {
 
-  public InMemoryEngine create() {
+  public static InMemoryEngine create() {
     final int partitionId = 1;
     final int partitionCount = 1;
     final int port = SocketUtil.getNextAddress().getPort();
@@ -70,18 +70,18 @@ public class EngineFactory {
         idleStateMonitor);
   }
 
-  private ControlledActorClock createActorClock() {
+  private static ControlledActorClock createActorClock() {
     return new ControlledActorClock();
   }
 
-  private ActorScheduler createAndStartActorScheduler(final ActorClock clock) {
+  private static ActorScheduler createAndStartActorScheduler(final ActorClock clock) {
     final ActorScheduler scheduler =
         ActorScheduler.newActorScheduler().setActorClock(clock).build();
     scheduler.start();
     return scheduler;
   }
 
-  private LogStream createLogStream(
+  private static LogStream createLogStream(
       final LogStorage logStorage, final ActorSchedulingService scheduler, final int partitionId) {
     final LogStreamBuilder builder =
         LogStream.builder()
@@ -108,12 +108,12 @@ public class EngineFactory {
     return theFuture.join();
   }
 
-  private ZeebeDb<ZbColumnFamilies> createDatabase() {
+  private static ZeebeDb<ZbColumnFamilies> createDatabase() {
     final InMemoryDbFactory<ZbColumnFamilies> factory = new InMemoryDbFactory<>();
     return factory.createDb();
   }
 
-  private StreamProcessor createStreamProcessor(
+  private static StreamProcessor createStreamProcessor(
       final LogStream logStream,
       final ZeebeDb<ZbColumnFamilies> database,
       final ActorSchedulingService scheduler,

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/EngineFactory.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/EngineFactory.java
@@ -129,7 +129,7 @@ public class EngineFactory {
         .streamProcessorFactory(
             context ->
                 EngineProcessors.createEngineProcessors(
-                    context.listener(idleStateMonitor),
+                    context,
                     partitionCount,
                     subscriptionCommandSenderFactory.createSender(),
                     new SinglePartitionDeploymentDistributor(),

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/InMemoryEngineImpl.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/InMemoryEngineImpl.java
@@ -10,7 +10,6 @@ import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import io.grpc.Server;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.NotImplementedException;
 
 public class InMemoryEngineImpl implements InMemoryEngine {
@@ -97,16 +96,16 @@ public class InMemoryEngineImpl implements InMemoryEngine {
   @Override
   public void runOnIdleState(final Runnable callback) {
     throw new NotImplementedException("This feature is coming soon");
-//    idleStateMonitor.addCallback(callback);
+    //    idleStateMonitor.addCallback(callback);
   }
 
   @Override
   public void waitForIdleState() {
     throw new NotImplementedException("This feature is coming soon");
-//    final CompletableFuture<Void> idleState = new CompletableFuture<>();
-//
-//    runOnIdleState(() -> idleState.complete(null));
-//
-//    idleState.join();
+    //    final CompletableFuture<Void> idleState = new CompletableFuture<>();
+    //
+    //    runOnIdleState(() -> idleState.complete(null));
+    //
+    //    idleState.join();
   }
 }

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/InMemoryEngineImpl.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/InMemoryEngineImpl.java
@@ -11,6 +11,7 @@ import io.grpc.Server;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.NotImplementedException;
 
 public class InMemoryEngineImpl implements InMemoryEngine {
 
@@ -95,15 +96,17 @@ public class InMemoryEngineImpl implements InMemoryEngine {
 
   @Override
   public void runOnIdleState(final Runnable callback) {
-    idleStateMonitor.addCallback(callback);
+    throw new NotImplementedException("This feature is coming soon");
+//    idleStateMonitor.addCallback(callback);
   }
 
   @Override
   public void waitForIdleState() {
-    final CompletableFuture<Void> idleState = new CompletableFuture<>();
-
-    runOnIdleState(() -> idleState.complete(null));
-
-    idleState.join();
+    throw new NotImplementedException("This feature is coming soon");
+//    final CompletableFuture<Void> idleState = new CompletableFuture<>();
+//
+//    runOnIdleState(() -> idleState.complete(null));
+//
+//    idleState.join();
   }
 }

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/RecordStreamSourceImpl.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/RecordStreamSourceImpl.java
@@ -33,7 +33,7 @@ public class RecordStreamSourceImpl implements RecordStreamSource {
 
   private final LogStreamReader logStreamReader;
   private final int partitionId;
-  private final List<Record<?>> records = new ArrayList<>();
+  private List<Record<?>> records = new ArrayList<>();
   private long lastPosition = -1L;
 
   public RecordStreamSourceImpl(final LogStreamReader logStreamReader, final int partitionId) {

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/RecordStreamSourceImpl.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/RecordStreamSourceImpl.java
@@ -131,7 +131,7 @@ public class RecordStreamSourceImpl implements RecordStreamSource {
       new CompactRecordLogger(recordsList).log();
     } else {
       System.out.println("===== records (count: ${count()}) =====");
-      recordsList.forEach(Record::toJson);
+      recordsList.forEach(record -> System.out.println(record.toJson()));
       System.out.println("---------------------------");
     }
   }

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/db/Bytes.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/db/Bytes.java
@@ -3,7 +3,6 @@ package io.camunda.zeebe.bpmnassert.testengine.db;
 import io.camunda.zeebe.db.DbValue;
 import java.util.Arrays;
 import org.agrona.ExpandableArrayBuffer;
-import org.jetbrains.annotations.NotNull;
 
 /** Wrapper around a {@code byte[]} to make it {@code Comparable} */
 final class Bytes implements Comparable<Bytes> {
@@ -34,7 +33,7 @@ final class Bytes implements Comparable<Bytes> {
   }
 
   @Override
-  public int compareTo(@NotNull final Bytes other) {
+  public int compareTo(final Bytes other) {
 
     final int EQUAL = 0;
     final int SMALLER = -1;

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/db/InMemoryDbColumnFamily.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/db/InMemoryDbColumnFamily.java
@@ -103,7 +103,7 @@ final class InMemoryDbColumnFamily<
   @Override
   public void whileEqualPrefix(
       final DbKey keyPrefix, final BiConsumer<KeyType, ValueType> visitor) {
-    whileEqualPrefix(context, keyInstance, valueInstance, visitor);
+    whileEqualPrefix(context, keyPrefix, keyInstance, valueInstance, new Visitor<>(visitor));
   }
 
   @Override

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="io.zeebe" level="debug"/>
+        <Logger name="io.camunda.zeebe" level="debug"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/DeploymentAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/DeploymentAssertTest.java
@@ -3,7 +3,7 @@ package io.camunda.zeebe.bpmnassert.assertions;
 import static io.camunda.zeebe.bpmnassert.assertions.BpmnAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
@@ -14,7 +14,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@ZeebeAssertions
+@ZeebeProcessTest
 class DeploymentAssertTest {
 
   public static final String WRONG_VALUE = "wrong value";

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/DeploymentAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/DeploymentAssertTest.java
@@ -4,14 +4,13 @@ import static io.camunda.zeebe.bpmnassert.assertions.BpmnAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackMultipleTasks;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import org.assertj.core.api.Assertions;
-import org.camunda.community.eze.RecordStreamSource;
-import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -19,8 +18,6 @@ import org.junit.jupiter.api.Test;
 class DeploymentAssertTest {
 
   public static final String WRONG_VALUE = "wrong value";
-
-  private ZeebeEngine engine;
 
   // These tests are for testing assertions as well as examples for users
   @Nested

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssertTest.java
@@ -3,7 +3,7 @@ package io.camunda.zeebe.bpmnassert.assertions;
 import static io.camunda.zeebe.bpmnassert.assertions.BpmnAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities;
@@ -20,7 +20,7 @@ import org.assertj.core.api.StringAssert;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@ZeebeAssertions
+@ZeebeProcessTest
 class IncidentAssertTest {
 
   public static final String WRONG_VALUE = "wrong value";

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssertTest.java
@@ -27,7 +27,6 @@ class IncidentAssertTest {
   public static final String ERROR_CODE = "error";
   public static final String ERROR_MESSAGE = "error occurred";
 
-
   // These tests are for testing assertions as well as examples for users
   @Nested
   class HappyPathTests {

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssertTest.java
@@ -4,6 +4,8 @@ import static io.camunda.zeebe.bpmnassert.assertions.BpmnAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -15,7 +17,6 @@ import java.util.Collections;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.StringAssert;
-import org.camunda.community.eze.RecordStreamSource;
 import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,6 @@ class IncidentAssertTest {
   public static final String ERROR_CODE = "error";
   public static final String ERROR_MESSAGE = "error occurred";
 
-  private ZeebeEngine engine;
 
   // These tests are for testing assertions as well as examples for users
   @Nested
@@ -35,6 +35,7 @@ class IncidentAssertTest {
 
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     void testHasErrorType() {
@@ -250,6 +251,7 @@ class IncidentAssertTest {
   class UnhappyPathTests {
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     void testHasErrorTypeFailure() {

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/IncidentAssertTest.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.StringAssert;
-import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/JobAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/JobAssertTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.data.Offset.offset;
 
-import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities;
@@ -24,7 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@ZeebeAssertions
+@ZeebeProcessTest
 class JobAssertTest {
 
   public static final String WRONG_VALUE = "wrong value";

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/JobAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/JobAssertTest.java
@@ -1,7 +1,10 @@
 package io.camunda.zeebe.bpmnassert.assertions;
 
 import static io.camunda.zeebe.bpmnassert.assertions.BpmnAssert.assertThat;
-import static io.camunda.zeebe.bpmnassert.util.Utilities.*;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.activateSingleJob;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.deployProcess;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.data.Offset.offset;
@@ -18,7 +21,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
-import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/JobAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/JobAssertTest.java
@@ -7,6 +7,8 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.data.Offset.offset;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
@@ -16,7 +18,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
-import org.camunda.community.eze.RecordStreamSource;
 import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,13 +29,12 @@ class JobAssertTest {
   public static final String ERROR_CODE = "error";
   public static final String ERROR_MSG = "error occurred";
 
-  private ZeebeEngine engine;
-
   // These tests are for testing assertions as well as examples for users
   @Nested
   class HappyPathTests {
     private ZeebeClient client;
     private RecordStreamSource recordStreamSource;
+    private InMemoryEngine engine;
 
     @Test
     void testHasElementId() {
@@ -220,6 +220,7 @@ class JobAssertTest {
   class UnhappyPathTests {
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     void testHasElementIdFailure() {

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
@@ -28,7 +28,6 @@ class MessageAssertTest {
   public static final String WRONG_CORRELATION_KEY = "wrongcorrelationkey";
   public static final String WRONG_MESSAGE_NAME = "wrongmessagename";
 
-
   @Nested
   class HappyPathTests {
 

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
@@ -9,7 +9,7 @@ import static io.camunda.zeebe.bpmnassert.util.Utilities.sendMessage;
 import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@ZeebeAssertions
+@ZeebeProcessTest
 class MessageAssertTest {
 
   public static final String CORRELATION_KEY = "correlationkey";

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
@@ -5,15 +5,14 @@ import static io.camunda.zeebe.bpmnassert.util.Utilities.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
-import org.camunda.community.eze.RecordStreamSource;
-import org.camunda.community.eze.ZeebeEngine;
-import org.camunda.community.eze.ZeebeEngineClock;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -24,14 +23,13 @@ class MessageAssertTest {
   public static final String WRONG_CORRELATION_KEY = "wrongcorrelationkey";
   public static final String WRONG_MESSAGE_NAME = "wrongmessagename";
 
-  private ZeebeEngine engine;
-  private ZeebeEngineClock clock;
 
   @Nested
   class HappyPathTests {
 
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     void testHasBeenCorrelated() {
@@ -163,6 +161,7 @@ class MessageAssertTest {
 
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     void testHasBeenCorrelatedFailure() {

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
@@ -1,7 +1,12 @@
 package io.camunda.zeebe.bpmnassert.assertions;
 
 import static io.camunda.zeebe.bpmnassert.assertions.BpmnAssert.assertThat;
-import static io.camunda.zeebe.bpmnassert.util.Utilities.*;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackMessageEvent;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackMessageStartEvent;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.deployProcess;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.increaseTime;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.sendMessage;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssertTest.java
@@ -6,10 +6,11 @@ import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import org.camunda.community.eze.RecordStreamSource;
 import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,14 +20,13 @@ class ProcessAssertTest {
 
   public static final String WRONG_VALUE = "wrong value";
 
-  private ZeebeEngine engine;
-
   // These tests are for testing assertions as well as examples for users
   @Nested
   class HappyPathTests {
 
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     public void testHasBPMNProcessId() {
@@ -130,6 +130,7 @@ class ProcessAssertTest {
 
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     public void testHasBPMNProcessIdFailure() {

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssertTest.java
@@ -5,7 +5,7 @@ import static io.camunda.zeebe.bpmnassert.util.Utilities.deployProcess;
 import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
@@ -14,7 +14,7 @@ import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@ZeebeAssertions
+@ZeebeProcessTest
 class ProcessAssertTest {
 
   public static final String WRONG_VALUE = "wrong value";

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssertTest.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssertTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -29,7 +29,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@ZeebeAssertions
+@ZeebeProcessTest
 class ProcessInstanceAssertTest {
   private static final Map<String, Object> TYPED_TEST_VARIABLES = new HashMap<>();
 
@@ -280,12 +280,11 @@ class ProcessInstanceAssertTest {
     public void testProcessInstanceIsNotWaitingAtNonExistingElement() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
+
+      // when
       final ProcessInstanceEvent instanceEvent =
           startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
       final String nonExistingElementId = "non-existing-task";
-
-      // when
-      completeTask(engine, client, nonExistingElementId);
 
       // then
       assertThat(instanceEvent).isNotWaitingAtElement(nonExistingElementId);
@@ -736,12 +735,11 @@ class ProcessInstanceAssertTest {
     public void testProcessInstanceWaitingAtNonExistingElementFailure() {
       // given
       deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
+
+      // when
       final ProcessInstanceEvent instanceEvent =
           startProcessInstance(engine, client, ProcessPackMultipleTasks.PROCESS_ID);
       final String nonExistingTaskId = "non-existing-task";
-
-      // when
-      completeTask(engine, client, nonExistingTaskId);
 
       // then
       assertThatThrownBy(() -> assertThat(instanceEvent).isWaitingAtElement(nonExistingTaskId))

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssertTest.java
@@ -1,13 +1,22 @@
 package io.camunda.zeebe.bpmnassert.assertions;
 
 import static io.camunda.zeebe.bpmnassert.assertions.BpmnAssert.assertThat;
-import static io.camunda.zeebe.bpmnassert.util.Utilities.*;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackMessageEvent;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackMultipleTasks;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.completeTask;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.deployProcess;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.sendMessage;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
+import static io.camunda.zeebe.bpmnassert.util.Utilities.waitForIdleState;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -17,15 +26,12 @@ import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
-import org.camunda.community.eze.RecordStreamSource;
-import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @ZeebeAssertions
 class ProcessInstanceAssertTest {
   private static final Map<String, Object> TYPED_TEST_VARIABLES = new HashMap<>();
-  private ZeebeEngine engine;
 
   static {
     TYPED_TEST_VARIABLES.put("stringProperty", "stringValue");
@@ -40,6 +46,7 @@ class ProcessInstanceAssertTest {
 
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     public void testProcessInstanceIsStarted() {
@@ -467,6 +474,7 @@ class ProcessInstanceAssertTest {
 
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test
     public void testProcessInstanceIsStartedFailure() {
@@ -1057,6 +1065,7 @@ class ProcessInstanceAssertTest {
 
     private RecordStreamSource recordStreamSource;
     private ZeebeClient client;
+    private InMemoryEngine engine;
 
     @Test // regression test for #78
     public void testShouldCaptureLatestValueOfVariable() {

--- a/src/test/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertionsExtensionTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertionsExtensionTest.java
@@ -3,7 +3,8 @@ package io.camunda.zeebe.bpmnassert.extensions;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-import org.camunda.community.eze.RecordStreamSource;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
+import io.camunda.zeebe.protocol.record.Record;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -12,10 +13,13 @@ import org.mockito.Mockito;
 class ZeebeAssertionsExtensionTest {
 
   @Nested
-  class MissingRecordStreamSource {
+  class MultipleInjectedFields {
+
+    private RecordStreamSource recordStreamSourceOne;
+    private RecordStreamSource recordStreamSourceTwo;
 
     @Test
-    public void testExtensionThrowsExceptionWhenMissingRecordStreamSource() {
+    public void testMultipleInjectedFieldsThrowError() {
       // given
       final ZeebeAssertionsExtension extension = new ZeebeAssertionsExtension();
       final ExtensionContext extensionContext = mock(ExtensionContext.class);
@@ -28,35 +32,8 @@ class ZeebeAssertionsExtensionTest {
       assertThatThrownBy(() -> extension.beforeEach(extensionContext))
           .isInstanceOf(IllegalStateException.class)
           .hasMessage(
-              "Expected a field of type RecordStreamSource to be declared in the test class, "
-                  + "but none has been found. Please make sure a field of type RecordStreamSource"
-                  + " has been declared in the test class.");
-    }
-  }
-
-  @Nested
-  class MissingZeebeClient {
-
-    // In order to test that the ZeebeClient is missing all the other required fields must be
-    // present, even though they are unused in this test
-    private RecordStreamSource recordStreamSource;
-
-    @Test
-    public void testExtensionThrowsExceptionWhenMissingZeebeClient() {
-      // given
-      final ZeebeAssertionsExtension extension = new ZeebeAssertionsExtension();
-      final ExtensionContext extensionContext = mock(ExtensionContext.class);
-
-      // when
-      Mockito.<Class<?>>when(extensionContext.getRequiredTestClass()).thenReturn(this.getClass());
-      Mockito.when(extensionContext.getRequiredTestInstance()).thenReturn(this);
-
-      // then
-      assertThatThrownBy(() -> extension.beforeEach(extensionContext))
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessage(
-              "Expected a field of type ZeebeClient to be declared in the test class, "
-                  + "but none has been found. Please make sure a field of type ZeebeClient has been "
+              "Expected at most one field of type RecordStreamSourceImpl, but found 2. "
+                  + "Please make sure at most one field of type RecordStreamSourceImpl has been "
                   + "declared in the test class.");
     }
   }

--- a/src/test/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertionsExtensionTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeAssertionsExtensionTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
-import io.camunda.zeebe.protocol.record.Record;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeProcessTestExtensionTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/extensions/ZeebeProcessTestExtensionTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mockito;
 
-class ZeebeAssertionsExtensionTest {
+class ZeebeProcessTestExtensionTest {
 
   @Nested
   class MultipleInjectedFields {
@@ -20,7 +20,7 @@ class ZeebeAssertionsExtensionTest {
     @Test
     public void testMultipleInjectedFieldsThrowError() {
       // given
-      final ZeebeAssertionsExtension extension = new ZeebeAssertionsExtension();
+      final ZeebeProcessTestExtension extension = new ZeebeProcessTestExtension();
       final ExtensionContext extensionContext = mock(ExtensionContext.class);
 
       // when

--- a/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessEventInspectionsTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessEventInspectionsTest.java
@@ -5,7 +5,7 @@ import static io.camunda.zeebe.bpmnassert.inspections.InspectionUtility.findProc
 import static io.camunda.zeebe.bpmnassert.util.Utilities.deployProcess;
 import static io.camunda.zeebe.bpmnassert.util.Utilities.increaseTime;
 
-import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.inspections.model.InspectedProcessInstance;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
@@ -17,7 +17,7 @@ import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-@ZeebeAssertions
+@ZeebeProcessTest
 class ProcessEventInspectionsTest {
 
   private static final String WRONG_TIMER_ID = "wrongtimer";

--- a/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessEventInspectionsTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessEventInspectionsTest.java
@@ -7,15 +7,14 @@ import static io.camunda.zeebe.bpmnassert.util.Utilities.increaseTime;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
 import io.camunda.zeebe.bpmnassert.inspections.model.InspectedProcessInstance;
+import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackTimerStartEvent;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import java.time.Duration;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
-import org.camunda.community.eze.RecordStreamSource;
-import org.camunda.community.eze.ZeebeEngine;
-import org.camunda.community.eze.ZeebeEngineClock;
 import org.junit.jupiter.api.Test;
 
 @ZeebeAssertions
@@ -24,8 +23,7 @@ class ProcessEventInspectionsTest {
   private static final String WRONG_TIMER_ID = "wrongtimer";
 
   private ZeebeClient client;
-  private ZeebeEngine engine;
-  private ZeebeEngineClock clock;
+  private InMemoryEngine engine;
   private RecordStreamSource recordStreamSource;
 
   @Test

--- a/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessInstanceInspectionsTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessInstanceInspectionsTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
-import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Test;
 
 @ZeebeAssertions

--- a/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessInstanceInspectionsTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessInstanceInspectionsTest.java
@@ -5,7 +5,7 @@ import static io.camunda.zeebe.bpmnassert.inspections.InspectionUtility.findProc
 import static io.camunda.zeebe.bpmnassert.util.Utilities.deployProcesses;
 import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
 
-import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
+import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.inspections.model.InspectedProcessInstance;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
 import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
@@ -16,7 +16,7 @@ import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-@ZeebeAssertions
+@ZeebeProcessTest
 public class ProcessInstanceInspectionsTest {
 
   private ZeebeClient client;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessInstanceInspectionsTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessInstanceInspectionsTest.java
@@ -7,12 +7,13 @@ import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeAssertions;
 import io.camunda.zeebe.bpmnassert.inspections.model.InspectedProcessInstance;
+import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
+import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackCallActivity;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
-import org.camunda.community.eze.RecordStreamSource;
 import org.camunda.community.eze.ZeebeEngine;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +21,7 @@ import org.junit.jupiter.api.Test;
 public class ProcessInstanceInspectionsTest {
 
   private ZeebeClient client;
-  private ZeebeEngine engine;
+  private InMemoryEngine engine;
   private RecordStreamSource recordStreamSource;
 
   @Test

--- a/src/test/java/io/camunda/zeebe/bpmnassert/testengine/db/InMemoryZeebeDbTransactionTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/testengine/db/InMemoryZeebeDbTransactionTest.java
@@ -9,7 +9,10 @@ package io.camunda.zeebe.bpmnassert.testengine.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.db.*;
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.db.impl.DbLong;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/util/Utilities.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/util/Utilities.java
@@ -155,10 +155,10 @@ public class Utilities {
   }
 
   public static void completeTask(
-      final InMemoryEngine engine, final ZeebeClient client, final String elementId) {
+      final InMemoryEngine engine, final ZeebeClient client, final String taskId) {
     final List<Record<JobRecordValue>> records =
         StreamFilter.jobRecords(engine.getRecordStream())
-            .withElementId(elementId)
+            .withElementId(taskId)
             .withIntent(JobIntent.CREATED)
             .stream()
             .collect(Collectors.toList());
@@ -167,6 +167,9 @@ public class Utilities {
       final Record<JobRecordValue> lastRecord;
       lastRecord = records.get(records.size() - 1);
       client.newCompleteCommand(lastRecord.getKey()).send().join();
+    } else {
+      throw new IllegalStateException(
+          String.format("Tried to complete task `%s`, but it was not found", taskId));
     }
 
     waitForIdleState(engine);

--- a/src/test/java/io/camunda/zeebe/bpmnassert/util/Utilities.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/util/Utilities.java
@@ -156,11 +156,12 @@ public class Utilities {
 
   public static void completeTask(
       final InMemoryEngine engine, final ZeebeClient client, final String elementId) {
-    final List<Record<JobRecordValue>> records = StreamFilter.jobRecords(engine.getRecordStream())
-        .withElementId(elementId)
-        .withIntent(JobIntent.CREATED)
-        .stream()
-        .collect(Collectors.toList());
+    final List<Record<JobRecordValue>> records =
+        StreamFilter.jobRecords(engine.getRecordStream())
+            .withElementId(elementId)
+            .withIntent(JobIntent.CREATED)
+            .stream()
+            .collect(Collectors.toList());
 
     if (!records.isEmpty()) {
       final Record<JobRecordValue> lastRecord;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/util/Utilities.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/util/Utilities.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.bpmnassert.util;
 
+import io.camunda.zeebe.bpmnassert.filters.StreamFilter;
+import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
@@ -11,8 +13,9 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import org.camunda.community.eze.ZeebeEngine;
+import java.util.stream.Collectors;
 
 public class Utilities {
 
@@ -84,12 +87,12 @@ public class Utilities {
   }
 
   public static ProcessInstanceEvent startProcessInstance(
-      final ZeebeEngine engine, final ZeebeClient client, final String processId) {
+      final InMemoryEngine engine, final ZeebeClient client, final String processId) {
     return startProcessInstance(engine, client, processId, new HashMap<>());
   }
 
   public static ProcessInstanceEvent startProcessInstance(
-      final ZeebeEngine engine,
+      final InMemoryEngine engine,
       final ZeebeClient client,
       final String processId,
       final Map<String, Object> variables) {
@@ -111,7 +114,7 @@ public class Utilities {
   }
 
   // TODO find a better solution for this
-  public static void waitForIdleState(final ZeebeEngine engine) {
+  public static void waitForIdleState(final InMemoryEngine engine) {
     try {
       Thread.sleep(100);
     } catch (final InterruptedException e) {
@@ -121,7 +124,7 @@ public class Utilities {
   }
 
   public static PublishMessageResponse sendMessage(
-      final ZeebeEngine engine,
+      final InMemoryEngine engine,
       final ZeebeClient client,
       final String messageName,
       final String correlationKey) {
@@ -129,7 +132,7 @@ public class Utilities {
   }
 
   public static PublishMessageResponse sendMessage(
-      final ZeebeEngine engine,
+      final InMemoryEngine engine,
       final ZeebeClient client,
       final String messageName,
       final String correlationKey,
@@ -146,22 +149,25 @@ public class Utilities {
     return response;
   }
 
-  public static void increaseTime(final ZeebeEngine engine, final Duration duration) {
-    engine.clock().increaseTime(duration);
+  public static void increaseTime(final InMemoryEngine engine, final Duration duration) {
+    engine.increaseTime(duration);
     waitForIdleState(engine);
   }
 
   public static void completeTask(
-      final ZeebeEngine engine, final ZeebeClient client, final String elementId) {
-    Record<JobRecordValue> lastRecord = null;
-    for (final Record<JobRecordValue> record : engine.jobRecords().withElementId(elementId)) {
-      if (record.getIntent().equals(JobIntent.CREATED)) {
-        lastRecord = record;
-      }
-    }
-    if (lastRecord != null) {
+      final InMemoryEngine engine, final ZeebeClient client, final String elementId) {
+    final List<Record<JobRecordValue>> records = StreamFilter.jobRecords(engine.getRecordStream())
+        .withElementId(elementId)
+        .withIntent(JobIntent.CREATED)
+        .stream()
+        .collect(Collectors.toList());
+
+    if (!records.isEmpty()) {
+      final Record<JobRecordValue> lastRecord;
+      lastRecord = records.get(records.size() - 1);
       client.newCompleteCommand(lastRecord.getKey()).send().join();
     }
+
     waitForIdleState(engine);
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
- Added the injection of the engine, client en recordstream to the `ZeebeAssertionsExtension`
- Removed the EZE dependency and added Zeebe + Log4J dependencies
- Fixed all the unit tests so that they can run with the new engine

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
