### PR TITLE
Re-enable IdleStateMonitor

### DIFF
--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/EngineFactory.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/EngineFactory.java
@@ -129,7 +129,7 @@ public class EngineFactory {
         .streamProcessorFactory(
             context ->
                 EngineProcessors.createEngineProcessors(
-                    context,
+                    context.listener(idleStateMonitor),
                     partitionCount,
                     subscriptionCommandSenderFactory.createSender(),
                     new SinglePartitionDeploymentDistributor(),

--- a/src/main/java/io/camunda/zeebe/bpmnassert/testengine/InMemoryEngineImpl.java
+++ b/src/main/java/io/camunda/zeebe/bpmnassert/testengine/InMemoryEngineImpl.java
@@ -10,7 +10,7 @@ import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import io.grpc.Server;
 import java.io.IOException;
 import java.time.Duration;
-import org.apache.commons.lang3.NotImplementedException;
+import java.util.concurrent.CompletableFuture;
 
 public class InMemoryEngineImpl implements InMemoryEngine {
 
@@ -95,17 +95,15 @@ public class InMemoryEngineImpl implements InMemoryEngine {
 
   @Override
   public void runOnIdleState(final Runnable callback) {
-    throw new NotImplementedException("This feature is coming soon");
-    //    idleStateMonitor.addCallback(callback);
+    idleStateMonitor.addCallback(callback);
   }
 
   @Override
   public void waitForIdleState() {
-    throw new NotImplementedException("This feature is coming soon");
-    //    final CompletableFuture<Void> idleState = new CompletableFuture<>();
-    //
-    //    runOnIdleState(() -> idleState.complete(null));
-    //
-    //    idleState.join();
+    final CompletableFuture<Void> idleState = new CompletableFuture<>();
+
+    runOnIdleState(() -> idleState.complete(null));
+
+    idleState.join();
   }
 }

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/DeploymentAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/DeploymentAssertTest.java
@@ -4,7 +4,6 @@ import static io.camunda.zeebe.bpmnassert.assertions.BpmnAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
-import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackMultipleTasks;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/MessageAssertTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
-import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessAssertTest.java
@@ -7,7 +7,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
-import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackLoopingServiceTask;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssertTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/assertions/ProcessInstanceAssertTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
-import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessEventInspectionsTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessEventInspectionsTest.java
@@ -8,7 +8,6 @@ import static io.camunda.zeebe.bpmnassert.util.Utilities.increaseTime;
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.inspections.model.InspectedProcessInstance;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
-import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackTimerStartEvent;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessInstanceInspectionsTest.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/inspections/ProcessInstanceInspectionsTest.java
@@ -8,7 +8,6 @@ import static io.camunda.zeebe.bpmnassert.util.Utilities.startProcessInstance;
 import io.camunda.zeebe.bpmnassert.extensions.ZeebeProcessTest;
 import io.camunda.zeebe.bpmnassert.inspections.model.InspectedProcessInstance;
 import io.camunda.zeebe.bpmnassert.testengine.InMemoryEngine;
-import io.camunda.zeebe.bpmnassert.testengine.RecordStreamSource;
 import io.camunda.zeebe.bpmnassert.util.Utilities.ProcessPackCallActivity;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;

--- a/src/test/java/io/camunda/zeebe/bpmnassert/util/Utilities.java
+++ b/src/test/java/io/camunda/zeebe/bpmnassert/util/Utilities.java
@@ -113,14 +113,8 @@ public class Utilities {
     return client.newActivateJobsCommand().jobType(jobType).maxJobsToActivate(1).send().join();
   }
 
-  // TODO find a better solution for this
   public static void waitForIdleState(final InMemoryEngine engine) {
-    try {
-      Thread.sleep(100);
-    } catch (final InterruptedException e) {
-      e.printStackTrace();
-      throw new IllegalStateException("Sleep was interrupted");
-    }
+    engine.waitForIdleState();
   }
 
   public static PublishMessageResponse sendMessage(
@@ -151,6 +145,12 @@ public class Utilities {
 
   public static void increaseTime(final InMemoryEngine engine, final Duration duration) {
     engine.increaseTime(duration);
+    try {
+      // we need to wait some physical time so that InMemoryEngine has a chance to fire the timers
+      Thread.sleep(50);
+    } catch (InterruptedException e) {
+      // do nothing
+    }
     waitForIdleState(engine);
   }
 


### PR DESCRIPTION
This commit re-enables `IdleStateMonitor` and fixes it to make it usable.

Learnings:
- we need to be mindful of multi-threading
- the sequence of events is not always intuitive. E.g. when the stream processor is writing the follow-up events, then the listener calls for the new log entries and the skipped entries can come in before the stream processor finished writing all events.
- Because of that, the old mechanism detected an idle state prematurely, i.e. after the first follow-up event was written to the log and immediately skipped by the record stream processor. It didn't wait whether more follow-up events are to come
- Therefore, there is now a timer started when the first idle state is detected.
- The timer delay may depend on the speed of the machine. So maybe we need to tune this going forward.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6
closes #71
closes #77

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
